### PR TITLE
Implement a generic worker for the Measurement Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ advertisers.**
 
 | Status | Coverage | Branch | Description |
 | :----- | :--------- | :----- | :---------- |
-| [![Build Status](https://travis-ci.org/google/crmint.svg?branch=develop)](https://travis-ci.org/google/crmint) | - | [dev](https://github.com/google/crmint/tree/dev) | Latest build, use it at your own risks  |
+| [![Build Status](https://travis-ci.org/google/crmint.svg?branch=dev)](https://travis-ci.org/google/crmint) | - | [dev](https://github.com/google/crmint/tree/dev) | Latest build, use it at your own risks  |
 | [![Build Status](https://travis-ci.org/google/crmint.svg?branch=master)](https://travis-ci.org/google/crmint) | - | [master](https://github.com/google/crmint/tree/master) | Production ready releases |
 
 > You can have data without information, but you cannot have information

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -819,7 +819,7 @@ class BQToMeasurementProtocol(MeasurementProtocolWorker):
   def _execute(self):
     # Retrieves data from BigQuery.
     self._bq_setup()
-    query = 'SELECT * FROM %s.%s.%s' % (
+    query = 'SELECT * FROM `%s.%s.%s`' % (
         self._params['bq_project_id'],
         self._params['bq_dataset_id'],
         self._params['bq_table_id'])

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -814,8 +814,8 @@ class BQToMeasurementProtocol(BQWorker, MeasurementProtocolWorker):
       data = dict(zip(fields, row))
       try:
         self.retry(self._send_hit)(**data)
-      except MeasurementProtocolException as inst:
-        self.log_error(inst.message)
+      except MeasurementProtocolException as e:
+        self.log_error(e.message)
 
   def _execute(self):
     # Retrieves data from BigQuery.

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -773,7 +773,7 @@ class MeasurementProtocolException(WorkerException):
 class MeasurementProtocolWorker(Worker):
   """Abstract Measurement Protocol worker."""
 
-  def _send_event_hit(self, user_agent='CRMint / 0.1', **kwargs):
+  def _send_hit(self, user_agent='CRMint / 0.1', **kwargs):
     """Send a measurement protocol hit.
 
     Arguments:
@@ -821,7 +821,7 @@ class BQToMeasurementProtocol(MeasurementProtocolWorker):
     for row in query_data:
       data = dict(zip(fields, row))
       try:
-        self.retry(self._send_event_hit)(**data)
+        self.retry(self._send_hit)(**data)
       except MeasurementProtocolException as inst:
         self.log_error(inst.message)
 

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -783,13 +783,19 @@ class MeasurementProtocolWorker(Worker):
     return payload
 
   def _prepare_payloads_for_batch_request(self, payloads):
-    """Merges payloads to send them as a batch request.
+    """Merges payloads to send them in a batch request.
 
     Arguments:
-      payloads list of payload, each payload being a list of
-          tuples representing key/value pairs.
+      payloads list of payload, each payload being a dictionary.
 
-    Returns: list from the concatenation of existing_payload and new_payload.
+    Returns: concatenated elements from each payloads as key/value tuples.
+        For example:
+
+          [
+            ('param1', 'value10'), ('param2', 'value20'),
+            ('param1', 'value11'), ('param2', 'value21'),
+            ...
+          ]
     """
     assert isinstance(payloads, list) or isinstance(payloads, tuple)
     return reduce(lambda x, y: x+y, map(lambda p: p.items(), payloads))

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -50,6 +50,9 @@ AVAILABLE = (
     'BQToMeasurementProtocol',
 )
 
+# Defines how many times to retry on failure, default to 5 times.
+DEFAULT_MAX_RETRIES = os.environ.get('MAX_RETRIES', 5)
+
 
 # pylint: disable=too-few-public-methods
 
@@ -121,13 +124,13 @@ class Worker(object):
   def _enqueue(self, worker_class, worker_params, delay=0):
     self._workers_to_enqueue.append((worker_class, worker_params, delay))
 
-  def retry(self, func):
+  def retry(self, func, max_retries=DEFAULT_MAX_RETRIES):
     """Decorator implementing retries with exponentially increasing delays."""
     @wraps(func)
     def func_with_retries(*args, **kwargs):
       """Retriable version of function being decorated."""
       tries = 0
-      while tries < 5:
+      while tries < max_retries:
         try:
           return func(*args, **kwargs)
         except HttpError as e:

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -826,11 +826,11 @@ class BQToMeasurementProtocol(BQWorker, MeasurementProtocolWorker):
         self._params['bq_table_id'])
     query_results = client.run_sync_query(query)
     query_results.use_legacy_sql = False
-    query_results.run()
+    self.retry(query_results.run)()
 
     page_token = None
     while True:
-      query_data = query_results.fetch_data(
+      query_data = self.retry(query_results.fetch_data)(
           max_results=10000,
           page_token=page_token)
       self._process_query_results(query_data)

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -766,6 +766,7 @@ class MLPredictor(MLWorker):
 
 
 class MeasurementProtocolException(WorkerException):
+  """Measurement Protocol execution exception."""
   pass
 
 
@@ -820,7 +821,7 @@ class BQToMeasurementProtocol(MeasurementProtocolWorker):
     for row in query_data:
       data = dict(zip(fields, row))
       try:
-        self._send_event_hit(**data)
+        self.retry(self._send_event_hit)(**data)
       except MeasurementProtocolException as inst:
         self.log_error(inst.message)
 

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -872,11 +872,6 @@ class BQToMeasurementProtocol(BQWorker, MeasurementProtocolWorker):
 
     if query_iterator.next_page_token is not None:
       # Spawn a new worker for the next batch
-      worker_params = {
-        'bq_project_id': self._params['bq_project_id'],
-        'bq_dataset_id': self._params['bq_dataset_id'],
-        'bq_table_id': self._params['bq_table_id'],
-        'bq_batch_size': self._params['bq_batch_size'],
-        'bg_page_token': query_iterator.next_page_token,
-      }
-      self._enqueue('BQToMeasurementProtocol', worker_params, 0)
+      worker_params = self._params.copy()
+      worker_params['bg_page_token'] = query_iterator.next_page_token
+      self._enqueue(self.__class__.__name__, worker_params, 0)

--- a/backends/tests/unit/core/workers_tests.py
+++ b/backends/tests/unit/core/workers_tests.py
@@ -298,7 +298,7 @@ class TestBQToMeasurementProtocol(unittest.TestCase):
             'tableId': 'mock_table',
         },
         'jobReference': {
-            'jobId': 'one-row-query',
+            'jobId': 'two-rows-query',
         },
         'rows': [
             {
@@ -310,7 +310,20 @@ class TestBQToMeasurementProtocol(unittest.TestCase):
                     {'v': 'category'},
                     {'v': 'action'},
                     {'v': 'label'},
-                    {'v': 'value'},
+                    {'v': 0.9},
+                    {'v': 'User Agent / 1.0'},
+                ]
+            },
+            {
+                'f': [
+                    {'v': 'UA-12345-1'},
+                    {'v': '35009a79-1a05-49d7-b876-2b884d0f825b'},
+                    {'v': 'event'},
+                    {'v': 1},
+                    {'v': 'category'},
+                    {'v': 'action'},
+                    {'v': 'label'},
+                    {'v': 0.8},
                     {'v': 'User Agent / 1.0'},
                 ]
             }
@@ -324,7 +337,7 @@ class TestBQToMeasurementProtocol(unittest.TestCase):
                 {'name': 'ec', 'type': 'STRING'},
                 {'name': 'ea', 'type': 'STRING'},
                 {'name': 'el', 'type': 'STRING'},
-                {'name': 'ev', 'type': 'STRING'},
+                {'name': 'ev', 'type': 'FLOAT'},
                 {'name': 'ua', 'type': 'STRING'},
             ]
         }
@@ -338,23 +351,34 @@ class TestBQToMeasurementProtocol(unittest.TestCase):
     self._patched_post.assert_called_once()
     self.assertEqual(
         self._patched_post.call_args[0][0],
-        'https://www.google-analytics.com/collect')
+        'https://www.google-analytics.com/batch')
     self.assertEqual(
         self._patched_post.call_args[1],
         {
             'headers': {'user-agent': 'CRMint / 0.1'},
-            'data': {
-                'ni': 1.0,
-                'el': 'label',
-                'cid': '35009a79-1a05-49d7-b876-2b884d0f825b',
-                'ea': 'action',
-                'ec': 'category',
-                't': 'event',
-                'v': 1,
-                'tid': 'UA-12345-1',
-                'ev': 'value',
-                'ua': 'User Agent / 1.0'
-            }
+            'data': [
+                ('ni', 1.0),
+                ('el', 'label'),
+                ('cid', '35009a79-1a05-49d7-b876-2b884d0f825b'),
+                ('ea', 'action'),
+                ('ec', 'category'),
+                ('t', 'event'),
+                ('v', 1),
+                ('tid', 'UA-12345-1'),
+                ('ev', 0.9),
+                ('ua', 'User Agent / 1.0'),
+
+                ('ni', 1.0),
+                ('el', 'label'),
+                ('cid', '35009a79-1a05-49d7-b876-2b884d0f825b'),
+                ('ea', 'action'),
+                ('ec', 'category'),
+                ('t', 'event'),
+                ('v', 1),
+                ('tid', 'UA-12345-1'),
+                ('ev', 0.8),
+                ('ua', 'User Agent / 1.0'),
+            ]
         })
 
   @mock.patch('time.sleep')
@@ -430,7 +454,7 @@ class TestBQToMeasurementProtocol(unittest.TestCase):
     patched_enqueue = patcher_worker_enqueue.start()
 
     self._worker._execute()
-    self.assertEqual(self._patched_post.call_count, 2)
+    self.assertEqual(self._patched_post.call_count, 1)
     patched_enqueue.assert_called_once()
     self.assertEqual(patched_enqueue.call_args[0][0], 'BQToMeasurementProtocol')
     self.assertEqual(patched_enqueue.call_args[0][1]['bg_page_token'], 'abc')

--- a/backends/tests/unit/core/workers_tests.py
+++ b/backends/tests/unit/core/workers_tests.py
@@ -276,7 +276,7 @@ class TestBQToMeasurementProtocol(unittest.TestCase):
     del response_json_copy['jobReference']
     mock_dataset = mock.Mock()
     mock_dataset._client = self._client
-    mock_table = Table.from_api_repr(response_json_copy, mock_dataset)
+    mock_table = Table('mock_table', mock_dataset)
     self._client._connection.api_request.return_value = response_json
     self._client.dataset.return_value = mock_dataset
     mock_dataset.table.return_value = mock_table


### PR DESCRIPTION
This worker is a basic wrapper around the Measurement Protocol api.

Missing features are:

- [x] uses batch requests
- [x] spawn new worker when it reaches the AppEngine standard timeout limit

NB: We took this approach to ensure the full compatibility with the current api.