### PR TITLE
Enable Google Cloud SQL API during cloud setup

### DIFF
--- a/scripts/cloud/setup.sh
+++ b/scripts/cloud/setup.sh
@@ -131,6 +131,7 @@ gcloud services enable \
   logging.googleapis.com \
   storage-api.googleapis.com \
   storage-component.googleapis.com \
+  sqladmin.googleapis.com \
   --async
 # ------------------------- END ENABLE REQUIRED APIS -------------------------
 echo


### PR DESCRIPTION
Cloud SQL Administration API (sqladmin.googleapis.com) is requierd when
using Cloud SQL Proxy.