### PR TITLE
Fix the batch request body formatting

### DIFF
--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -23,6 +23,7 @@ import json
 import os
 from random import random
 import time
+import urllib
 import uuid
 
 from apiclient.discovery import build
@@ -788,17 +789,14 @@ class MeasurementProtocolWorker(Worker):
     Arguments:
       payloads list of payload, each payload being a dictionary.
 
-    Returns: concatenated elements from each payloads as key/value tuples.
+    Returns: concatenated url-encoded payloads.
         For example:
 
-          [
-            ('param1', 'value10'), ('param2', 'value20'),
-            ('param1', 'value11'), ('param2', 'value21'),
-            ...
-          ]
+          param1=value10&param2=value20
+          param1=value11&param2=value21
     """
     assert isinstance(payloads, list) or isinstance(payloads, tuple)
-    return reduce(lambda x, y: x+y, map(lambda p: p.items(), payloads))
+    return '\n'.join(map(lambda p: urllib.urlencode(p), payloads))
 
   def _send_batch_hits(self, batch_payload, user_agent='CRMint / 0.1'):
     """Sends a batch request to the Measurement Protocol endpoint.
@@ -842,7 +840,8 @@ class BQToMeasurementProtocol(BQWorker, MeasurementProtocolWorker):
     try:
       self.retry(self._send_batch_hits, max_retries=1)(batch_payload)
     except MeasurementProtocolException as e:
-      self.log_error(e.message)
+      escaped_message = e.message.replace('%', '%%')
+      self.log_error(escaped_message)
 
   def _process_query_results(self, query_data, query_schema,
       payloads_batch_size=20):

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -832,7 +832,6 @@ class BQToMeasurementProtocol(BQWorker, MeasurementProtocolWorker):
       ('bq_dataset_id', 'string', True, '', 'BQ Dataset ID'),
       ('bq_table_id', 'string', True, '', 'BQ Table ID'),
       ('bq_batch_size', 'number', True, int(1e5), 'BQ Batch Size'),
-      ('bg_page_token', 'string', False, '', 'BQ Page Token (optional)'),
       ('mp_batch_size', 'number', True, 20, 'Measurement Protocol batch size (https://goo.gl/7VeWuB)'),
   ]
 
@@ -862,7 +861,7 @@ class BQToMeasurementProtocol(BQWorker, MeasurementProtocolWorker):
   def _execute(self):
     self._bq_setup()
     self._table.reload()
-    page_token = self._params['bg_page_token'] or None
+    page_token = self._params.get('bg_page_token', None)
     query_iterator = self.retry(self._table.fetch_data, max_retries=1)(
         max_results=int(self._params['bq_batch_size']),
         page_token=page_token)

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -833,6 +833,7 @@ class BQToMeasurementProtocol(BQWorker, MeasurementProtocolWorker):
       ('bq_table_id', 'string', True, '', 'BQ Table ID'),
       ('bq_batch_size', 'number', True, int(1e5), 'BQ Batch Size'),
       ('bg_page_token', 'string', False, '', 'BQ Page Token (optional)'),
+      ('mp_batch_size', 'number', True, 20, 'Measurement Protocol batch size (https://goo.gl/7VeWuB)'),
   ]
 
   def _send_payload_list(self, payload_list):
@@ -843,8 +844,7 @@ class BQToMeasurementProtocol(BQWorker, MeasurementProtocolWorker):
       escaped_message = e.message.replace('%', '%%')
       self.log_error(escaped_message)
 
-  def _process_query_results(self, query_data, query_schema,
-      payloads_batch_size=20):
+  def _process_query_results(self, query_data, query_schema):
     """Sends event hits from query data."""
     fields = [f.name for f in query_schema]
     payload_list = []
@@ -852,7 +852,7 @@ class BQToMeasurementProtocol(BQWorker, MeasurementProtocolWorker):
       data = dict(zip(fields, row))
       payload = self._get_payload_from_data(data)
       payload_list.append(payload)
-      if len(payload_list) >= payloads_batch_size:
+      if len(payload_list) >= self._params['mp_batch_size']:
         self._send_payload_list(payload_list)
         payload_list = []
     if payload_list:

--- a/backends/tests/unit/core/workers_tests.py
+++ b/backends/tests/unit/core/workers_tests.py
@@ -356,29 +356,9 @@ class TestBQToMeasurementProtocol(unittest.TestCase):
         self._patched_post.call_args[1],
         {
             'headers': {'user-agent': 'CRMint / 0.1'},
-            'data': [
-                ('ni', 1.0),
-                ('el', 'label'),
-                ('cid', '35009a79-1a05-49d7-b876-2b884d0f825b'),
-                ('ea', 'action'),
-                ('ec', 'category'),
-                ('t', 'event'),
-                ('v', 1),
-                ('tid', 'UA-12345-1'),
-                ('ev', 0.9),
-                ('ua', 'User Agent / 1.0'),
-
-                ('ni', 1.0),
-                ('el', 'label'),
-                ('cid', '35009a79-1a05-49d7-b876-2b884d0f825b'),
-                ('ea', 'action'),
-                ('ec', 'category'),
-                ('t', 'event'),
-                ('v', 1),
-                ('tid', 'UA-12345-1'),
-                ('ev', 0.8),
-                ('ua', 'User Agent / 1.0'),
-            ]
+            'data':
+"""ni=1.0&el=label&cid=35009a79-1a05-49d7-b876-2b884d0f825b&ea=action&ec=category&t=event&v=1&tid=UA-12345-1&ev=0.9&ua=User+Agent+%2F+1.0
+ni=1.0&el=label&cid=35009a79-1a05-49d7-b876-2b884d0f825b&ea=action&ec=category&t=event&v=1&tid=UA-12345-1&ev=0.8&ua=User+Agent+%2F+1.0""",
         })
 
   @mock.patch('time.sleep')


### PR DESCRIPTION
The Measurement Protocol batch endpoint expect a [very specific format](https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#batch).

This PR ensures that we send one line per hit in the body of the POST request.

Cheers