### PR TITLE
Add quick-start scripts (issue #31)

### DIFF
--- a/scripts/cloud/quick-start-dev.sh
+++ b/scripts/cloud/quick-start-dev.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Google Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CURRENT_DIR=$(pwd)
+
+# Clones the crmint repository in the home directory.
+cd "$HOME"
+git clone https://github.com/google/crmint.git
+cd crmint
+
+# Switch to the dev branch
+git checkout dev
+
+# Configures the GCP project with the resources needed.
+bin/app cloud setup
+
+# Deploy the App Engine services.
+bin/app cloud deploy
+
+# Restores initial directory.
+cd "$CURRENT_DIR"

--- a/scripts/cloud/quick-start.sh
+++ b/scripts/cloud/quick-start.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Google Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CURRENT_DIR=$(pwd)
+
+# Clones the crmint repository in the home directory.
+cd "$HOME"
+git clone https://github.com/google/crmint.git
+cd crmint
+
+# Configures the GCP project with the resources needed.
+bin/app cloud setup
+
+# Deploy the App Engine services.
+bin/app cloud deploy
+
+# Restores initial directory.
+cd "$CURRENT_DIR"


### PR DESCRIPTION
Quick-start scripts from [Pierre's README.md](https://gist.github.com/dulacp/0b6104e3b1b09adfd1e89aacd442cb62) moved to `scripts/cloud/` to address [issue #31](https://github.com/google/crmint/issues/31)