### PR TITLE
Freeze urllib3 to version 1.23

### DIFF
--- a/backends/core/requirements.txt
+++ b/backends/core/requirements.txt
@@ -1,3 +1,4 @@
+urllib3==1.23
 Flask==0.12.2
 Flask-Cors==3.0.2
 Flask-Migrate==2.0.3


### PR DESCRIPTION
After upgrade of `urllib3` to version 1.24 the following error started to appear breaking CRMint's functionality:

```
AttributeError: 'VerifiedHTTPSConnection' object has no attribute '_tunnel_host'
```