### PR TITLE
Fix Cloud Project ID validation regular expression

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     ports:
       - "3306:3306"
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
       MYSQL_DATABASE: crmintapp
       MYSQL_USER: crmintapp
       MYSQL_PASSWORD: crmintapp


### PR DESCRIPTION
As per Issue #58, the regular expression that validates Cloud Projects ID's in the Deploy Guide does not capture some valid project ID's.