### PR TITLE
Add BQML Trainer worker minimal implementation

### DIFF
--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -49,6 +49,9 @@ AVAILABLE = (
     'MLPredictor',
     'StorageCleaner',
     'StorageToBQImporter',
+    'Commenter',
+    'BQToMeasurementProtocol',
+    'BQMLTrainer',
 )
 
 # Defines how many times to retry on failure, default to 5 times.
@@ -931,3 +934,23 @@ class BQToMeasurementProtocolProcessor(BQWorker, MeasurementProtocolWorker):
         page_token=page_token)
     query_first_page = next(query_iterator.pages)
     self._process_query_results(query_first_page, query_iterator.schema)
+
+
+class BQMLTrainer(BQWorker):
+  """Worker to run BQML SQL queries in BigQuery."""
+
+  PARAMS = [
+      ('query', 'sql', True, '', 'Query'),
+      ('bq_project_id', 'string', False, '', 'BQ Project ID'),
+  ]
+
+  def _bq_setup(self):
+    self._client = self._get_client()
+    self._job_name = '%i_%i_%s_%s' % (self._pipeline_id, self._job_id,
+                                      self.__class__.__name__, uuid.uuid4())
+
+  def _execute(self):
+    self._bq_setup()
+    job = self._client.run_async_query(self._job_name, self._params['query'])
+    job.use_legacy_sql = False
+    self._begin_and_wait(job)

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -942,13 +942,10 @@ class BQMLTrainer(BQWorker):
       ('bq_project_id', 'string', False, '', 'BQ Project ID'),
   ]
 
-  def _bq_setup(self):
-    self._client = self._get_client()
-    self._job_name = '%i_%i_%s_%s' % (self._pipeline_id, self._job_id,
-                                      self.__class__.__name__, uuid.uuid4())
-
   def _execute(self):
-    self._bq_setup()
-    job = self._client.run_async_query(self._job_name, self._params['query'])
+    client = self._get_client()
+    job_name = '%i_%i_%s_%s' % (self._pipeline_id, self._job_id,
+                                self.__class__.__name__, uuid.uuid4())
+    job = client.run_async_query(job_name, self._params['query'])
     job.use_legacy_sql = False
     self._begin_and_wait(job)

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -39,6 +39,7 @@ from google.cloud.exceptions import ClientError
 _KEY_FILE = os.path.join(os.path.dirname(__file__), '..', 'data',
                          'service-account.json')
 AVAILABLE = (
+    'BQMLTrainer',
     'BQQueryLauncher',
     'BQToMeasurementProtocol',
     'BQToStorageExporter',
@@ -49,9 +50,6 @@ AVAILABLE = (
     'MLPredictor',
     'StorageCleaner',
     'StorageToBQImporter',
-    'Commenter',
-    'BQToMeasurementProtocol',
-    'BQMLTrainer',
 )
 
 # Defines how many times to retry on failure, default to 5 times.


### PR DESCRIPTION
This worker aims is to run the CREATE MODEL sql query to create and train a model from a BigQuery SQL query.

A typical query to create a model would be:

```sql
#standardSQL
 
/**
 * Create and train the model.
 */
CREATE OR REPLACE MODEL `my_project.my_dataset.modelv1`
OPTIONS(
  model_type='logistic_reg',
  input_label_cols=['will_buy_later']
) AS
SELECT
  ...
FROM my_data
```

Cheers