### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/backends/appengine_config.py
+++ b/backends/appengine_config.py
@@ -15,6 +15,7 @@
 """
 Initialize the App Engine sdk.
 """
+from __future__ import print_function
 
 import os
 from google.appengine.ext import vendor
@@ -37,4 +38,4 @@ if os.environ.get('SERVER_SOFTWARE', '').startswith('Development'):
   # Use the App Engine Requests adapter. This makes sure that Requests uses
   # URLFetch.
   requests_toolbelt_appengine.monkeypatch()
-  print "Appengine requests patched"
+  print("Appengine requests patched")

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -542,7 +542,7 @@ class GADataImporter(GAWorker):
       while response is None and tries < 5:
         try:
           status, response = request.next_chunk()
-        except HttpError, e:
+        except HttpError as e:
           if e.resp.status in [404, 500, 502, 503, 504]:
             tries += 1
             delay = 5 * 2 ** (tries + random())

--- a/scripts/deploy/tasks/seeds.py
+++ b/scripts/deploy/tasks/seeds.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2018 Google Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,4 +24,4 @@ for setting in settings:
     gsetting = GeneralSetting()
     gsetting.name = setting
     gsetting.save()
-    print 'Added setting', setting
+    print('Added setting', setting)


### PR DESCRIPTION
* Use __print()__ function in both Python 2 and Python 3
    * __print()__ is a function in Python 3.
* Old style exceptions --> new style for Python 3
    * Python 3 treats old style exceptions as syntax errors but new style exceptions work as expected in both Python 2 and Python 3.