### PR TITLE
Add a stage file migration command

### DIFF
--- a/cli/stages/stage_name.py.example
+++ b/cli/stages/stage_name.py.example
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Version of the stage definition
+spec_version = "v2.0"
+
 ###
 # Variables for stage
 ###

--- a/cli/utils/shared.py
+++ b/cli/utils/shared.py
@@ -27,7 +27,7 @@ from cli.utils import spinner
 
 
 def execute_command(step_name, command, cwd='.', report_empty_err=True, debug=False, stream_output_in_debug=True, force_std_out=False):
-  assert isinstance(command, str)
+  assert isinstance(command, basestring)
   pipe_output = (None if (debug and stream_output_in_debug) else subprocess.PIPE)
   if force_std_out:
     pipe_output = None

--- a/cli/utils/shared.py
+++ b/cli/utils/shared.py
@@ -40,6 +40,7 @@ def execute_command(step_name, command, cwd='.', report_empty_err=True, debug=Fa
         command,
         cwd=cwd,
         shell=True,
+        executable='/bin/bash',
         stdout=pipe_output,
         stderr=pipe_output)
     out, err = pipe.communicate()


### PR DESCRIPTION
Now we have a command to migrate old stage files to the new python format:

**Simply invoke the migration command should be sufficient**
```sh
$ . venv/bin/activate
(venv) $ crmint stages migrate
````

**Or with the specific stage file name if necessary**
```sh
$ . venv/bin/activate
(venv) $ crmint stages migrate --stage_name crmint-super-instance
```

Cheers