### PR TITLE
Hotfix/cloud reset issues

### DIFF
--- a/backends/core/database.py
+++ b/backends/core/database.py
@@ -64,3 +64,10 @@ def load_fixtures(logger_func=None):
       general_setting.save()
       if logger_func:
         logger_func('Added setting %s' % setting)
+
+def reset_jobs_and_pipelines_statuses_to_idle():
+  from core.models import Pipeline
+  for pipeline in Pipeline.all():
+    for job in pipeline.jobs:
+      job.update(status='idle')
+    pipeline.update(status='idle')

--- a/backends/flask_tasks.py
+++ b/backends/flask_tasks.py
@@ -25,8 +25,5 @@ def add(app):
   @app.cli.command()
   def reset_pipelines():
     """Reset pipelines and jobs statuses."""
-    from core.models import Pipeline
-    for pipeline in Pipeline.all():
-      for job in pipeline.jobs:
-        job.update(status='idle')
-      pipeline.update(status='idle')
+    from core import database
+    database.reset_jobs_and_pipelines_statuses_to_idle()

--- a/cli/commands/cloud.py
+++ b/cli/commands/cloud.py
@@ -579,6 +579,7 @@ def reset(stage_name, debug):
       display_workdir,
       copy_src_to_workdir,
       install_backends_dependencies,
+      download_cloud_sql_proxy,
       start_cloud_sql_proxy,
       prepare_flask_envars,
       run_reset_pipelines,


### PR DESCRIPTION
- [x] flask task `reset-pipelines` moved from `flask_tasks.py` to avoid double import of `core.models`;
- [x] Cloud SQL Proxy setup step added to `cloud reset` CLI command to make sure that corresponding env vars are initialised.