### PR TITLE
Implement inline function to fetch a value from a BigQuery table

### DIFF
--- a/backends/core/inline.py
+++ b/backends/core/inline.py
@@ -14,6 +14,22 @@
 
 from datetime import datetime
 from datetime import timedelta
+import os
+from google.cloud import bigquery
+from google.cloud.exceptions import NotFound
+
+
+_SESSION = None
+
+
+def open_session():
+  global _SESSION
+  _SESSION = {'bq_cache': {}}
+
+
+def close_session():
+  global _SESSION
+  _SESSION = None
 
 
 def _today(format):
@@ -34,9 +50,53 @@ def _days_since(date, format):
   return (datetime.today() - datetime.strptime(str(date), format)).days
 
 
+def _bigquery(table_name, field_name):
+  def _get_bq_client():
+    try:
+      return _SESSION['bq_client']
+    except KeyError:
+      key = os.path.join(os.path.dirname(__file__), '..', 'data',
+                         'service-account.json')
+      _SESSION['bq_client'] = bigquery.Client.from_service_account_json(key)
+      return _SESSION['bq_client']
+
+  def _fetch_bq_table_data(table_name):
+    client = _get_bq_client()
+    table_name_pieces = table_name.split('.')
+    if len(table_name_pieces) == 2:
+      dataset_id, table_id = table_name_pieces
+    elif len(table_name_pieces) == 3:
+      project_id, dataset_id, table_id = table_name_pieces
+      client.project = project_id
+    else:
+      raise ValueError('Malformed BigQuery table name: `%s`' % table_name)
+    dataset = client.dataset(dataset_id)
+    table = dataset.table(table_id)
+    try:
+      table.reload()
+    except NotFound:
+      raise ValueError('BigQuery table `%s` not found' % table_name)
+    field_names = [f.name for f in table.schema]
+    filed_values = list(table.fetch_data(max_results=1))[0]
+    _SESSION['bq_cache'][table_name] = dict(zip(field_names, filed_values))
+
+  if table_name not in _SESSION['bq_cache']:
+    _fetch_bq_table_data(table_name)
+  try:
+    value = _SESSION['bq_cache'][table_name][field_name]
+  except KeyError:
+    raise ValueError(
+        "No field '%s' in BigQuery table `%s`" % (field_name, table_name))
+  if isinstance(value, list):
+    return '\n'.join([str(e) for e in value])
+  else:
+    return value
+
+
 functions = {
     'today': _today,
     'days_ago': _days_ago,
     'hours_ago': _hours_ago,
     'days_since': _days_since,
+    'bigquery': _bigquery,
 }


### PR DESCRIPTION
`bigquery()` inline function allows to pull values for pipeline and job parameters from BigQuery tables.

Usage:

- `{% bigquery('some_dataset.some_table', 'column_name') %}` will get the value of `column_name` column in the first row of `some_table` table from `some_dataset` dataset in the cloud project where CRMint has been deployed.
- `{% bigquery('other_project.some_dataset.some_table', 'column_name') %}` will get the value of `column_name` column in the first row of `some_table` table from `some_dataset` dataset in the `other_project` cloud project. CRMint must have read access to `other_project` project, of course.

Don't forget that basic expressions are allowed between `{%` and `%}`, and `bigquery()` is just a function that returns some value so these are valid examples too:

- `{% bigquery('some_dataset.some_table', 'some_column') / 100 + 42 %}` — arithmetic operations;
- `{% bigquery('some_dataset.some_table', 'some_column') and bigquery('some_dataset.some_table', 'some_other_column') %}` — boolean operations.