### PR TITLE
Bring back Python packages required for dev env.

### DIFF
--- a/backends/core/requirements_dev.txt
+++ b/backends/core/requirements_dev.txt
@@ -1,0 +1,3 @@
+requests_toolbelt==0.8.0
+requests==2.18.4
+

--- a/docker/backends/Dockerfile
+++ b/docker/backends/Dockerfile
@@ -54,14 +54,14 @@ WORKDIR /app
 COPY ./backends/core/requirements.txt /app/backends/core/requirements.txt
 COPY ./backends/ibackend/requirements.txt /app/backends/ibackend/requirements.txt
 COPY ./backends/jbackend/requirements.txt /app/backends/jbackend/requirements.txt
-COPY ./scripts/dev/requirements.txt /app/scripts/dev/requirements.txt
+COPY ./backends/core/requirements_dev.txt /app/backends/core/requirements_dev.txt
 
 # Install python dependencies
 WORKDIR /app/backends
 RUN apk add --update mariadb-client-libs \
     && apk add --no-cache --virtual .bootstrap-deps \
         bash curl python-dev musl-dev mariadb-dev gcc build-base \
-    && pip install -r /app/scripts/dev/requirements.txt -t lib_dev \
+    && pip install -r core/requirements_dev.txt -t lib_dev \
     && pip install -r ibackend/requirements.txt -t lib \
     && pip install -r jbackend/requirements.txt -t lib \
     && pip install "sphinx==1.7.2" "sphinx-autobuild==0.7.1" \


### PR DESCRIPTION
`requirements_dev.txt` was removed along with previous set of scripts replaced by the new CLI — it's time to bring it back to development environment :-)