### PR TITLE
Install script

### DIFF
--- a/docs/docs/quickstart/cloudshell.md
+++ b/docs/docs/quickstart/cloudshell.md
@@ -3,7 +3,7 @@
 1.  Execute the quickstart script :
 
     ```shell
-    curl https://raw.githubusercontent.com/dulacp/crmint/feature/install-script/scripts/install.sh | sudo bash
+    curl https://raw.githubusercontent.com/dulacp/crmint/feature/install-script/scripts/install.sh | bash
     ```
 
 1.  Once this script has completed executing, the installation is complete.

--- a/docs/docs/quickstart/cloudshell.md
+++ b/docs/docs/quickstart/cloudshell.md
@@ -3,7 +3,7 @@
 1.  Execute the quickstart script :
 
     ```shell
-    curl https://raw.githubusercontent.com/dulacp/crmint/feature/install-script/scripts/install.sh | bash
+    curl -L https://raw.githubusercontent.com/dulacp/crmint/feature/install-script/scripts/install.sh | bash
     ```
 
 1.  Once this script has completed executing, the installation is complete.

--- a/docs/docs/quickstart/cloudshell.md
+++ b/docs/docs/quickstart/cloudshell.md
@@ -3,8 +3,7 @@
 1.  Execute the quickstart script :
 
     ```shell
-    chmod +x ./scripts/cloud/quick-start.sh
-    ./scripts/cloud/quick-start.sh
+    curl https://raw.githubusercontent.com/dulacp/crmint/feature/install-script/scripts/install.sh | sudo bash
     ```
 
 1.  Once this script has completed executing, the installation is complete.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,7 +17,7 @@
 # Downloads the source code.
 if [ ! -d $HOME/crmint ]; then
   git clone https://github.com/google/crmint.git $HOME/crmint
-  echo "\nCloned crmint repository to your home directory: $HOME."
+  echo "\\nCloned crmint repository to your home directory: $HOME."
 fi
 cd $HOME/crmint
 
@@ -43,4 +43,4 @@ function crmint {
   command crmint \$@ || return
 }
 EOF
-echo "\nAdded a bash function to your $HOME/.bashrc file."
+echo "\\nAdded a bash function to your $HOME/.bashrc file."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -32,6 +32,7 @@ fi
 pip install --quiet -e cli/
 
 # Adds the wrapper function to the user `.bashrc` file.
+echo "\\nAdding a bash function to your $HOME/.bashrc file."
 cat <<EOF >>$HOME/.bashrc
 
 # CRMint wrapper function.
@@ -43,4 +44,6 @@ function crmint {
   command crmint \$@ || return
 }
 EOF
-echo "\\nAdded a bash function to your $HOME/.bashrc file."
+
+echo "Reloading the shell"
+exec bash

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,6 +23,7 @@ cd $HOME/crmint
 
 # TODO temp
 git checkout dev
+git pull --quiet --rebase
 
 # Installs the command-line.
 if [ ! -d venv ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Downloads the source code.
+if [ ! -d $HOME/crmint ]; then
+  git clone https://github.com/google/crmint.git $HOME/crmint
+  echo "\nCloned crmint repository to your home directory: $HOME."
+fi
+cd $HOME/crmint
+
+# TODO temp
+git checkout dev
+
+# Installs the command-line.
+if [ ! -d venv ]; then
+  virtualenv --python=python2 venv
+fi
+. venv/bin/activate
+pip install --quiet -e cli/
+
+# Adds the wrapper function to the user `.bashrc` file.
+cat <<EOF >>$HOME/.bashrc
+
+# CRMint wrapper function.
+# Automatically activates the virtualenv and makes the command
+# accessible from all directories
+function crmint {
+   cd \$HOME/crmint
+  . venv/bin/activate
+  command crmint \$@ || return
+}
+EOF
+echo "\nAdded a bash function to your $HOME/.bashrc file."


### PR DESCRIPTION
This small PR is meant for help new & old clients to update their CRMint installation.
We assume that they cloned the repo in their `$HOME` directory on CloudShell.

You can run the install/update script from my fork with the following command:

```shell
$ curl -L https://raw.githubusercontent.com/dulacp/crmint/feature/install-script/scripts/install.sh | bash
```

We can later create a short-url to the script reference on google/crmint repo, thanks to the `-L` option curl will follow the redirects.

Cheers