### PR TITLE
Hotfix/insight config path on gcp

### DIFF
--- a/backends/core/insight.py
+++ b/backends/core/insight.py
@@ -30,7 +30,7 @@ from threading import Timer
 
 import requests
 
-PROJECT_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), '../../'))
+PROJECT_DIR = os.path.join(os.path.dirname(__file__), '../../')
 DEFAULT_TRACKING_ID = "UA-127959147-2"
 INSIGHT_CONF_FILEPATH = os.path.join(PROJECT_DIR, 'backends/data/insight.json')
 

--- a/backends/core/insight.py
+++ b/backends/core/insight.py
@@ -30,9 +30,9 @@ from threading import Timer
 
 import requests
 
-PROJECT_DIR = os.path.join(os.path.dirname(__file__), '../../')
+PROJECT_DIR = os.path.join(os.path.dirname(__file__), '../')
 DEFAULT_TRACKING_ID = "UA-127959147-2"
-INSIGHT_CONF_FILEPATH = os.path.join(PROJECT_DIR, 'backends/data/insight.json')
+INSIGHT_CONF_FILEPATH = os.path.join(PROJECT_DIR, 'data/insight.json')
 
 
 class GAProvider(object):


### PR DESCRIPTION
The insight configuration files was referenced with `backends` in the relative url, but on the AppEngine `api-service` there is no backends directory.

I just removed one level of relative import.

Cheers