### PR TITLE
Catch SyntaxError, update param labels, correct param name in Commenter

### DIFF
--- a/backends/core/models.py
+++ b/backends/core/models.py
@@ -137,7 +137,7 @@ class Pipeline(BaseModel):
           param.populate_runtime_value(pipeline_context)
       inline.close_session()
       return True
-    except (InvalidExpression, TypeError, ValueError) as e:
+    except (InvalidExpression, TypeError, ValueError, SyntaxError) as e:
       inline.close_session()
       from core import cloud_logging
       job_id = '-'
@@ -637,6 +637,7 @@ class Param(BaseModel):
         elif obj and obj.__class__.__name__ == 'Job':
           param.job_id = obj.id
       param.name = arg_param['name']
+      param.label = arg_param['label']
       param.type = arg_param['type']
       if arg_param['type'] == 'boolean':
         param.value = arg_param['value']

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -158,7 +158,7 @@ class Commenter(Worker):
   def _execute(self):
     if not self._params['success']:
       msg = '"{}" is unchecked: {}'.format(
-          self.PARAMS[1][3],
+          self.PARAMS[1][4],
           self._params['comment'])
       raise WorkerException(msg)
 

--- a/backends/tests/integration/core/models_tests.py
+++ b/backends/tests/integration/core/models_tests.py
@@ -296,8 +296,8 @@ class TestPipelineImport(utils.ModelTestCase):
     job2 = models.Job.create()
     data = {
         'params': [
-            {'name': 'p1', 'type': 'string', 'value': 'foo'},
-            {'name': 'p2', 'type': 'string', 'value': 'bar'},
+            {'name': 'p1', 'label': 'P1', 'type': 'string', 'value': 'foo'},
+            {'name': 'p2', 'label': 'P2', 'type': 'string', 'value': 'bar'},
         ],
         'schedules': [
             {'id': None, 'cron': 'NEW1'},
@@ -311,8 +311,10 @@ class TestPipelineImport(utils.ModelTestCase):
     pipeline.import_data(data)
     self.assertEqual(len(pipeline.params.all()), 2)
     self.assertEqual(pipeline.params[0].name, 'p1')
+    self.assertEqual(pipeline.params[0].label, 'P1')
     self.assertEqual(pipeline.params[0].value, 'foo')
     self.assertEqual(pipeline.params[1].name, 'p2')
+    self.assertEqual(pipeline.params[1].label, 'P2')
     self.assertEqual(pipeline.params[1].value, 'bar')
     self.assertEqual(len(pipeline.jobs.all()), 2)
     self.assertEqual(pipeline.jobs[0].name, 'j1')

--- a/backends/tests/unit/core/models_tests.py
+++ b/backends/tests/unit/core/models_tests.py
@@ -67,8 +67,10 @@ class TestPipeline(utils.ModelTestCase):
         name='checkbox0',
         type='boolean')
     params = [
-        {'id': p1.id, 'name': 'checkbox1', 'type': 'boolean', 'value': '0'},
-        {'id': None, 'name': 'desc', 'type': 'text', 'value': 'Hello world!'},
+        {'id': p1.id, 'name': 'checkbox1', 'label': 'CheckBox',
+         'type': 'boolean', 'value': '0'},
+        {'id': None, 'name': 'desc', 'label': 'Text', 'type': 'text',
+         'value': 'Hello world!'},
     ]
     pipeline.assign_params(params)
     self.assertEqual(len(pipeline.params.all()), 2)
@@ -99,7 +101,8 @@ class TestPipeline(utils.ModelTestCase):
         {'id': None, 'cron': 'NEW1'}
     ]
     params = [
-        {'id': None, 'name': 'desc', 'type': 'text', 'value': 'Hello world!'}
+        {'id': None, 'name': 'desc', 'label': 'Description', 'type': 'text',
+         'value': 'Hello world!'}
     ]
     relations = {'schedules': schedules, 'params': params}
     self.assertEqual(len(pipeline.schedules.all()), 0)
@@ -216,7 +219,8 @@ class TestJob(utils.ModelTestCase):
         'condition': models.StartCondition.CONDITION.SUCCESS}
     ]
     params = [
-        {'id': None, 'name': 'desc', 'type': 'text', 'value': 'Hello world!'}
+        {'id': None, 'name': 'desc', 'label': 'Label', 'type': 'text',
+         'value': 'Hello world!'}
     ]
     relations = {'start_conditions': start_conditions, 'params': params}
     self.assertEqual(len(job1.start_conditions), 0)


### PR DESCRIPTION
This PR addresses the following bugs:

## Bug #84:

A pipeline won't start and will show nothing in logs if there is a syntax error in a job param expression, e.g. missing parentheses like this:

```
{% today('%Y-%m-%d' %}
```

## Bug #85:

When a `Commenter` job runs with "Finish successfully" flag unchecked, it fails with a meaningless message: `Execution failed: WorkerException: "False" is unchecked: …` in a pipeline log.

## Bug #86:

`Bad job param "None": …` shown in logs when the param's value is invalid. Log message should look like this: `Bad job param "BQ Project ID": …`