### PR TITLE
Hotfix/89

### DIFF
--- a/backends/core/models.py
+++ b/backends/core/models.py
@@ -140,16 +140,16 @@ class Pipeline(BaseModel):
     except (InvalidExpression, TypeError, ValueError, SyntaxError) as e:
       inline.close_session()
       from core import cloud_logging
-      job_id = '-'
-      worker_class = '-'
+      job_id = 'N/A'
+      worker_class = 'N/A'
       if param.job_id is not None:
         job_id = param.job_id
         worker_class = param.job.worker_class
-        message = 'Bad job param "%s": %s' % (param.label, e)
+        message = 'Invalid job parameter "%s": %s' % (param.label, e)
       elif param.pipeline_id is not None:
-        message = 'Bad pipeline param "%s": %s' % (param.label, e)
+        message = 'Invalid pipeline variable "%s": %s' % (param.label, e)
       else:
-        message = 'Bad global param "%s": %s' % (param.label, e)
+        message = 'Invalid global variable "%s": %s' % (param.label, e)
       cloud_logging.logger.log_struct({
           'labels': {
               'pipeline_id': self.id,
@@ -637,7 +637,10 @@ class Param(BaseModel):
         elif obj and obj.__class__.__name__ == 'Job':
           param.job_id = obj.id
       param.name = arg_param['name']
-      param.label = arg_param['label']
+      try:
+        param.label = arg_param['label']
+      except KeyError:
+        param.label = arg_param['name']
       param.type = arg_param['type']
       if arg_param['type'] == 'boolean':
         param.value = arg_param['value']

--- a/backends/ibackend/pipeline/views.py
+++ b/backends/ibackend/pipeline/views.py
@@ -357,7 +357,14 @@ class PipelineLogs(Resource):
               'job_name': job.name,
               'log_level': entry.payload.get('log_level', 'INFO')
           }
-          entries.append(log)
+        else:
+          log = {
+              'timestamp': entry.timestamp.__str__(),
+              'payload': entry.payload,
+              'job_name': 'N/A',
+              'log_level': entry.payload.get('log_level', 'INFO')
+          }
+        entries.append(log)
       next_page_token = iterator.next_page_token
     return {
         'entries': entries,


### PR DESCRIPTION
This hot fix addresses bug #89 (see quote below) and improves pipeline-level logging:

> Pipeline settings are not being saved when pipeline variables are specified. Same happens when saving global variables on the Settings tab. "500 Internal Server Error" is seen in the network panel in browser dev tools.