### PR TITLE
Set 5 mins timeout for URLFetch service in job-sevice's request handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # Use Dockerized infrastructure
 sudo: false
 language: python
+python:
+  - "2.7"
 
 # Cache our Gcloud SDK between commands
 cache:

--- a/backends/jbackend/cron/views.py
+++ b/backends/jbackend/cron/views.py
@@ -16,6 +16,8 @@
 import logging
 import time
 
+from google.appengine.api import urlfetch
+
 from croniter import croniter
 from flask import Blueprint
 from flask_restful import Resource
@@ -39,6 +41,7 @@ class Cron(Resource):
 
   def get(self):
     """Finds and enqueues pipelines scheduled to be executed now."""
+    urlfetch.set_default_fetch_deadline(300)
     for pipeline in Pipeline.where(run_on_schedule=True).all():
       logging.info('Checking schedules for pipeline %s', pipeline.name)
       for schedule in pipeline.schedules:

--- a/backends/jbackend/task/views.py
+++ b/backends/jbackend/task/views.py
@@ -16,9 +16,13 @@
 
 import logging
 import json
+
+from google.appengine.api import urlfetch
+
 from flask import Blueprint
 from flask import request
 from flask_restful import Resource, reqparse
+
 from core import workers
 from core.models import Job
 from jbackend.extensions import api
@@ -43,6 +47,7 @@ class Task(Resource):
         task_name = request.headers.get('X-AppEngine-TaskName')[11:]
 
     """
+    urlfetch.set_default_fetch_deadline(300)
     retries = int(request.headers.get('X-AppEngine-TaskExecutionCount'))
     args = parser.parse_args()
     logger.debug(args)


### PR DESCRIPTION
This hot fix addresses the issue of default 5 secs timeout in the App Engine's URLFetch service that handles all HTTP requests. This timeout is too short when it comes to Google Cloud API requests: the API requests are resulting in HTTP timeout error when the corresponding Cloud service takes more than 5 secs to complete the request.