### PR TITLE
Freeze http2lib at version < 0.16.0

### DIFF
--- a/backends/core/requirements.txt
+++ b/backends/core/requirements.txt
@@ -13,3 +13,4 @@ google-api-python-client==1.6.5
 google-cloud-logging==1.6.0
 GoogleAppEngineCloudStorageClient==1.9.22.1
 pyyaml==3.12
+httplib2<0.16.0


### PR DESCRIPTION
Related to [GCloud Upload httplib2.RedirectMissingLocation: Redirected but the response is missing a Location: header](https://stackoverflow.com/questions/59815620/gcloud-upload-httplib2-redirectmissinglocation-redirected-but-the-response-is-m). `http2lib` version frozen at < 0.16.0 — thank you [KevinTydlacka](https://stackoverflow.com/users/3347351/kevintydlacka) and [temoto](https://stackoverflow.com/users/73957/temoto) for providing the solution.