### PR TITLE
Fix error displayed when showing a pipeline in the UI

### DIFF
--- a/backends/core/requirements.txt
+++ b/backends/core/requirements.txt
@@ -14,3 +14,5 @@ google-cloud-logging==1.6.0
 GoogleAppEngineCloudStorageClient==1.9.22.1
 pyyaml==3.12
 httplib2<0.16.0
+Werkzeug==0.16.1
+

--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -21,8 +21,7 @@ import { Config } from './config';
 export class ApiService {
 
   protected host = this.getHost();
-  protected headers = new Headers({});
-  protected options = new RequestOptions({ headers: this.headers });
+  protected options = new RequestOptions({ headers: new Headers() });
 
   constructor(protected http: Http) { }
 
@@ -38,6 +37,10 @@ export class ApiService {
   }
 
   protected addContentTypeHeader() {
-    this.headers.set('Content-Type', 'application/json');
+    this.options.headers.set('Content-Type', 'application/json');
+  }
+
+  protected removeContentTypeHeader() {
+    this.options.headers.delete('Content-Type');
   }
 }

--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -21,7 +21,7 @@ import { Config } from './config';
 export class ApiService {
 
   protected host = this.getHost();
-  protected headers = new Headers({ 'Content-Type': 'application/json' });
+  protected headers = new Headers({});
   protected options = new RequestOptions({ headers: this.headers });
 
   constructor(protected http: Http) { }
@@ -35,5 +35,9 @@ export class ApiService {
   protected handleError(error: any): Promise<any> {
     console.error('An error occurred', error); // for demo purposes only
     return Promise.reject(error.message || error);
+  }
+
+  protected addContentTypeHeader() {
+    this.headers.set('Content-Type', 'application/json');
   }
 }

--- a/frontend/src/app/dashboard/shared/stages.service.ts
+++ b/frontend/src/app/dashboard/shared/stages.service.ts
@@ -24,6 +24,7 @@ export class StagesService extends ApiService {
   private url = `${this.getHost()}/stages`;
 
   getStages() {
+    this.removeContentTypeHeader();
     return this.http.get(this.url, this.options)
                     .toPromise()
                     .then(res => res.json() as Stage[])
@@ -39,7 +40,7 @@ export class StagesService extends ApiService {
   }
 
   deleteStage(id) {
-    this.addContentTypeHeader();
+    this.removeContentTypeHeader();
     return this.http.delete(this.getStageUrl(id))
                     .toPromise()
                     .catch(this.handleError);
@@ -54,6 +55,7 @@ export class StagesService extends ApiService {
   }
 
   getPipelinesForStage(stage) {
+    this.removeContentTypeHeader();
     return this.http.get(this.getPipelinesUrl(stage.sid), this.options)
                     .toPromise()
                     .then(res => {

--- a/frontend/src/app/dashboard/shared/stages.service.ts
+++ b/frontend/src/app/dashboard/shared/stages.service.ts
@@ -31,6 +31,7 @@ export class StagesService extends ApiService {
   }
 
   addStage(stage_data) {
+    this.addContentTypeHeader();
     return this.http.post(this.url, JSON.stringify(stage_data), this.options)
                     .toPromise()
                     .then(res => res.json() as Stage)
@@ -38,6 +39,7 @@ export class StagesService extends ApiService {
   }
 
   deleteStage(id) {
+    this.addContentTypeHeader();
     return this.http.delete(this.getStageUrl(id))
                     .toPromise()
                     .catch(this.handleError);

--- a/frontend/src/app/jobs/shared/jobs.service.ts
+++ b/frontend/src/app/jobs/shared/jobs.service.ts
@@ -29,6 +29,7 @@ export class JobsService extends ApiService {
     const params = new URLSearchParams();
     params.set('pipeline_id', pipeline_id);
     this.options.search = params;
+    this.removeContentTypeHeader();
     return this.http.get(this.url, this.options)
                     .toPromise()
                     .then(res => res.json())
@@ -36,6 +37,7 @@ export class JobsService extends ApiService {
   }
 
   getJob(id) {
+    this.removeContentTypeHeader();
     return this.http.get(this.getJobUrl(id))
                     .toPromise()
                     .then(res => res.json())
@@ -44,7 +46,7 @@ export class JobsService extends ApiService {
 
   addJob(job) {
     this.addContentTypeHeader();
-    return this.http.post(this.url, serialize(job), { headers: this.headers })
+    return this.http.post(this.url, serialize(job), { headers: this.options.headers })
                     .toPromise()
                     .then(res => res.json())
                     .catch(this.handleError);
@@ -52,14 +54,14 @@ export class JobsService extends ApiService {
 
   updateJob(job) {
     this.addContentTypeHeader();
-    return this.http.put(this.getJobUrl(job.id), serialize(job), { headers: this.headers })
+    return this.http.put(this.getJobUrl(job.id), serialize(job), { headers: this.options.headers })
                     .toPromise()
                     .then(res => res.json())
                     .catch(this.handleError);
   }
 
   deleteJob(id) {
-    this.addContentTypeHeader();
+    this.removeContentTypeHeader();
     return this.http.delete(this.getJobUrl(id))
                     .toPromise()
                     .then(res => res.json())
@@ -68,7 +70,7 @@ export class JobsService extends ApiService {
 
   startJob(id) {
     this.addContentTypeHeader();
-    return this.http.post(this.getJobUrl(id) + '/start', null, { headers: this.headers })
+    return this.http.post(this.getJobUrl(id) + '/start', null, { headers: this.options.headers })
                     .toPromise()
                     .then(res => res.json())
                     .catch(this.handleError);

--- a/frontend/src/app/jobs/shared/jobs.service.ts
+++ b/frontend/src/app/jobs/shared/jobs.service.ts
@@ -43,6 +43,7 @@ export class JobsService extends ApiService {
   }
 
   addJob(job) {
+    this.addContentTypeHeader();
     return this.http.post(this.url, serialize(job), { headers: this.headers })
                     .toPromise()
                     .then(res => res.json())
@@ -50,6 +51,7 @@ export class JobsService extends ApiService {
   }
 
   updateJob(job) {
+    this.addContentTypeHeader();
     return this.http.put(this.getJobUrl(job.id), serialize(job), { headers: this.headers })
                     .toPromise()
                     .then(res => res.json())
@@ -57,6 +59,7 @@ export class JobsService extends ApiService {
   }
 
   deleteJob(id) {
+    this.addContentTypeHeader();
     return this.http.delete(this.getJobUrl(id))
                     .toPromise()
                     .then(res => res.json())
@@ -64,6 +67,7 @@ export class JobsService extends ApiService {
   }
 
   startJob(id) {
+    this.addContentTypeHeader();
     return this.http.post(this.getJobUrl(id) + '/start', null, { headers: this.headers })
                     .toPromise()
                     .then(res => res.json())

--- a/frontend/src/app/jobs/shared/workers.service.ts
+++ b/frontend/src/app/jobs/shared/workers.service.ts
@@ -24,6 +24,7 @@ export class WorkersService extends ApiService {
   private url = `${this.getHost()}/workers`;
 
   getParamsForWorkerClass(worker_class) {
+    this.removeContentTypeHeader();
     return this.http.get(this.getWorkerParamsUrl(worker_class))
                     .toPromise()
                     .then(res => res.json() as Param[])
@@ -31,6 +32,7 @@ export class WorkersService extends ApiService {
   }
 
   getWorkers() {
+    this.removeContentTypeHeader();
     return this.http.get(this.url)
                     .toPromise()
                     .then(res => res.json())

--- a/frontend/src/app/pipelines/shared/pipelines.service.ts
+++ b/frontend/src/app/pipelines/shared/pipelines.service.ts
@@ -25,6 +25,7 @@ export class PipelinesService extends ApiService {
   private url = `${this.getHost()}/pipelines`;
 
   getPipelines() {
+    this.removeContentTypeHeader();
     return this.http.get(this.url, this.options)
                     .toPromise()
                     .then(res => res.json() as Pipeline[])
@@ -32,6 +33,7 @@ export class PipelinesService extends ApiService {
   }
 
   getPipeline(id) {
+    this.removeContentTypeHeader();
     return this.http.get(this.getPipelineUrl(id))
                     .toPromise()
                     .then(res => res.json() as Pipeline)
@@ -55,7 +57,7 @@ export class PipelinesService extends ApiService {
   }
 
   deletePipeline(id) {
-    this.addContentTypeHeader();
+    this.removeContentTypeHeader();
     return this.http.delete(this.getPipelineUrl(id))
                     .toPromise()
                     .catch(this.handleError);
@@ -80,15 +82,15 @@ export class PipelinesService extends ApiService {
   importPipeline(file: File) {
     const formData: FormData = new FormData();
     formData.append('upload_file', file, file.name);
-    const headers = new Headers();
-    const options = new RequestOptions({ headers: headers });
-    return this.http.post(this.url + '/import', formData, options)
+    this.removeContentTypeHeader();
+    return this.http.post(this.url + '/import', formData)
                     .toPromise()
                     .then(res => res.json())
                     .catch(this.handleError);
   }
 
   exportPipeline(id) {
+    this.removeContentTypeHeader();
     return this.http.get(this.getPipelineUrl(id) + '/export')
                     .toPromise()
                     .catch(this.handleError);
@@ -116,7 +118,7 @@ export class PipelinesService extends ApiService {
     }
 
     this.options.search = p;
-    this.addContentTypeHeader();
+    this.removeContentTypeHeader();
     return this.http.get(url, this.options)
                     .toPromise()
                     .then(res => res.json())

--- a/frontend/src/app/pipelines/shared/pipelines.service.ts
+++ b/frontend/src/app/pipelines/shared/pipelines.service.ts
@@ -39,6 +39,7 @@ export class PipelinesService extends ApiService {
   }
 
   addPipeline(pipeline) {
+    this.addContentTypeHeader();
     return this.http.post(this.url, JSON.stringify(pipeline), this.options)
                     .toPromise()
                     .then(res => res.json() as Pipeline)
@@ -46,6 +47,7 @@ export class PipelinesService extends ApiService {
   }
 
   updatePipeline(pipeline) {
+    this.addContentTypeHeader();
     return this.http.put(this.getPipelineUrl(pipeline.id), JSON.stringify(pipeline), this.options)
                     .toPromise()
                     .then(res => res.json() as Pipeline)
@@ -53,12 +55,14 @@ export class PipelinesService extends ApiService {
   }
 
   deletePipeline(id) {
+    this.addContentTypeHeader();
     return this.http.delete(this.getPipelineUrl(id))
                     .toPromise()
                     .catch(this.handleError);
   }
 
   startPipeline(id) {
+    this.addContentTypeHeader();
     return this.http.post(this.getPipelineUrl(id) + '/start', {}, this.options)
                     .toPromise()
                     .then(res => res.json() as Pipeline)
@@ -66,6 +70,7 @@ export class PipelinesService extends ApiService {
   }
 
   stopPipeline(id) {
+    this.addContentTypeHeader();
     return this.http.post(this.getPipelineUrl(id) + '/stop', {}, this.options)
                     .toPromise()
                     .then(res => res.json() as Pipeline)
@@ -90,6 +95,7 @@ export class PipelinesService extends ApiService {
   }
 
   updateRunOnSchedule(id, run_on_schedule) {
+    this.addContentTypeHeader();
     return this.http.patch(this.getPipelineUrl(id) + '/run_on_schedule', {run_on_schedule: run_on_schedule}, this.options)
                     .toPromise()
                     .then(res => res.json() as Pipeline)
@@ -110,6 +116,7 @@ export class PipelinesService extends ApiService {
     }
 
     this.options.search = p;
+    this.addContentTypeHeader();
     return this.http.get(url, this.options)
                     .toPromise()
                     .then(res => res.json())

--- a/frontend/src/app/settings/shared/settings.service.ts
+++ b/frontend/src/app/settings/shared/settings.service.ts
@@ -34,6 +34,7 @@ export class SettingsService extends ApiService {
   }
 
   saveVariables(variables: Param[]): Promise<Param[]> {
+    this.addContentTypeHeader();
     return this.http.put(this.variablesUrl, {variables: variables})
                .toPromise()
                .then(response => response.json() as Param[])
@@ -41,6 +42,7 @@ export class SettingsService extends ApiService {
   }
 
   saveSettings(settings: Setting[]) {
+    this.addContentTypeHeader();
     return this.http.put(this.settingsUrl, {settings: settings})
                .toPromise()
                .then(response => response.json())

--- a/frontend/src/app/settings/shared/settings.service.ts
+++ b/frontend/src/app/settings/shared/settings.service.ts
@@ -27,6 +27,7 @@ export class SettingsService extends ApiService {
   private settingsUrl = `${this.host}/general_settings`;
 
   getConfigData(): Promise<Config> {
+    this.removeContentTypeHeader();
     return this.http.get(this.configUrl)
                .toPromise()
                .then(response => response.json() as Config)


### PR DESCRIPTION
App Engine stopped stripping `Content-Type` header from GET requests since March 6, 2020. Flask doesn't like this (please refer to [Bad Request on GET with header Content-Type](https://github.com/flask-restful/flask-restful/issues/510) for details).

This patch ensures that CRMint's front-end application doesn't use `Content-Type: application/json` header in GET and DELETE requests to the back end service.