### PR TITLE
Fix broken Edit on GitHub links in docs

### DIFF
--- a/docsource/_includes/contribute-links.html
+++ b/docsource/_includes/contribute-links.html
@@ -2,5 +2,5 @@
 
 <div class="contribute-links">
 	<a href="{{ site.baseurl }}/contribute#{{ page.path }}">Contribution Guidelines</a>
-	<a href="{{ site.githuburl }}/edit/master/{{page.path}}"><p class="github">Edit <span class="file-name">{{file_name}}</span></p></a>
+	<a href="{{ site.githuburl }}/edit/master/docsource/{{page.path}}"><p class="github">Edit <span class="file-name">{{file_name}}</span></p></a>
 </div>


### PR DESCRIPTION
The documentation section of the CRMint website contains links to edit
the current page on GitHub. These links were broken when the docsource
was moved in efe4b9ba5c1f9f1645bc0baf4cb1b860abb1a2ff. For example, click _Edit index.md_ in the upper-right corner on https://google.github.io/crmint/docs/custom/.
This commit fixes that by adding the `docsource` path component to those links.