### PR TITLE
Worker sending mobile app conversions to Google Ads

### DIFF
--- a/backends/core/database.py
+++ b/backends/core/database.py
@@ -55,8 +55,10 @@ def load_fixtures(logger_func=None):
   :param: Logger function to display the loading state
   """
   from core import models
-  # added two more rows to list, for google ads auth code and refresh token
-  general_settings = ['client_id', 'client_secret', 'emails_for_notifications', 'google_ads_authentication_code', 'google_ads_refresh_token', 'developer_token']
+  general_settings = [
+      'client_id', 'client_secret', 'emails_for_notifications',
+      'google_ads_authentication_code', 'google_ads_refresh_token',
+      'developer_token', 'app_conversion_api_developer_token']
   for setting in general_settings:
     general_setting = models.GeneralSetting.where(name=setting).first()
     if not general_setting:

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -144,6 +144,10 @@ class Worker(object):
       while tries < max_retries:
         try:
           return func(*args, **kwargs)
+        except HttpError as e:
+          # If it is a client side error, then there's no reason to retry.
+          if e.resp.status > 399 and e.resp.status < 500:
+            raise e
         except HTTPError as e:
           # If it is a client side error, then there's no reason to retry.
           if e.code > 399 and e.code < 500:

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -60,7 +60,8 @@ AVAILABLE = (
     'StorageToBQImporter',
 )
 
-# Defines how many times to retry on failure, default to 3 times.
+# Defines how many times to retry a function wrapped in Worker.retry()
+# on failure, 3 times by default.
 DEFAULT_MAX_RETRIES = os.environ.get('MAX_RETRIES', 3)
 
 # pylint: disable=too-few-public-methods
@@ -81,7 +82,7 @@ class Worker(object):
 
   GLOBAL_SETTINGS = []
 
-  # Maximum number of execution attempts.
+  # Maximum number of worker execution attempts.
   MAX_ATTEMPTS = 1
 
   def __init__(self, params, pipeline_id, job_id):
@@ -145,7 +146,7 @@ class Worker(object):
           return func(*args, **kwargs)
         except HTTPError as e:
           # If it is a client side error, then there's no reason to retry.
-          if e.resp.status > 399 and e.resp.status < 500:
+          if e.code > 399 and e.code < 500:
             raise e
         except Exception as e:  # pylint: disable=broad-except
           tries += 1

--- a/backends/ibackend/ads_auth_code.py
+++ b/backends/ibackend/ads_auth_code.py
@@ -30,6 +30,9 @@ OAUTH2_REFRESH_HEADERS = {
 
 
 def get_url(client_id):
+  """ Create oauth client and use this to generate the URL to get the authorisation
+  code using client_id """
+
   oauthlib_client = oauth2.WebApplicationClient(client_id)
   # This is the URL construction for getting the authorisation code
   authorize_url = oauthlib_client.prepare_request_uri(
@@ -39,6 +42,10 @@ def get_url(client_id):
 
 
 def get_token(client_id, client_secret, ads_code):
+  """ Using authentication code retrieved from URL, take code, client_id and
+  client_secret to send HTTP request to fetch refresh token taken from parsed
+  response """
+
   oauthlib_client = oauth2.WebApplicationClient(client_id)
   # Prepare the access token request body --> makes a
   # request to the token endpoint by adding the following parameters

--- a/backends/tests/unit/core/workers_tests.py
+++ b/backends/tests/unit/core/workers_tests.py
@@ -132,7 +132,7 @@ class TestAbstractWorker(unittest.TestCase):
     fake_request = mock.Mock()
     fake_request.__name__ = 'foo'
     fake_request.side_effect = _raise_value_error_exception
-    with self.assertRaises(HttpError):
+    with self.assertRaises(HTTPError):
       worker.retry(fake_request)()
     self.assertEqual(fake_request.call_count, 1)
 

--- a/backends/tests/unit/core/workers_tests.py
+++ b/backends/tests/unit/core/workers_tests.py
@@ -18,9 +18,9 @@ import unittest
 from apiclient.errors import HttpError
 import cloudstorage
 from google.appengine.ext import testbed
-from google.cloud.bigquery.dataset import Dataset
 from google.cloud.bigquery.table import Table
 from google.cloud.exceptions import ClientError
+from urllib2 import HTTPError
 import mock
 
 from core import workers
@@ -114,10 +114,21 @@ class TestAbstractWorker(unittest.TestCase):
       worker.retry(fake_request)()
     self.assertGreaterEqual(fake_request.call_count, 2)
 
-  def test_retry_raises_error_if_bad_request_error(self):
+  def test_retry_raises_error_if_bad_request_error_in_apiclient(self):
     worker = workers.Worker({}, 1, 1)
     def _raise_value_error_exception(*args, **kwargs):
       raise HttpError(mock.Mock(status=400), '')
+    fake_request = mock.Mock()
+    fake_request.__name__ = 'foo'
+    fake_request.side_effect = _raise_value_error_exception
+    with self.assertRaises(HttpError):
+      worker.retry(fake_request)()
+    self.assertEqual(fake_request.call_count, 1)
+
+  def test_retry_raises_error_if_bad_request_error_in_urllib(self):
+    worker = workers.Worker({}, 1, 1)
+    def _raise_value_error_exception(*args, **kwargs):
+      raise HTTPError('http://example.com/', 400, '', [], None)
     fake_request = mock.Mock()
     fake_request.__name__ = 'foo'
     fake_request.side_effect = _raise_value_error_exception


### PR DESCRIPTION
`BQToAppConversionAPI` worker runs through a BigQuery table and sends each row as a mobile app conversion to Google Ads using [App Conversion Tracking and Remarketing API](https://developers.google.com/app-conversion-tracking/api/). Each field in the table's row is treated as a parameter of the [Conversion Tracking Request](https://developers.google.com/app-conversion-tracking/api/request-response-specs#conversion_tracking_request). In case Google Ads responds with an affirmative conversion tracking response, `BQToAppConversionAPI` sends corresponding [Cross-network Attribution Request](https://developers.google.com/app-conversion-tracking/api/request-response-specs#cross-network_attribution_request).