### PR TITLE
Automl pipeline support

### DIFF
--- a/backends/core/requirements.txt
+++ b/backends/core/requirements.txt
@@ -19,3 +19,4 @@ lxml==3.7.3
 oauth2client==4.1.3
 httplib2<0.16.0
 Werkzeug==0.16.1
+rsa==4.0

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -1517,7 +1517,7 @@ class AutoMLPredictor(AutoMLWorker):
     }
 
     # Launch the prediction and retrieve its operation name so we can track it.
-    self.log_info('Launching batch prediction job: %s', body)
+    self.log_info('Launching batch prediction job @ %s: %s', parent, body)
     client = self._get_automl_client(location=model_location)
     response = client.projects().locations().models() \
                      .batchPredict(name=model_name, body=body).execute()
@@ -1711,7 +1711,7 @@ class AutoMLTrainer(AutoMLWorker):
     }
 
     # Launch the prediction and retrieve its operation name so we can track it.
-    self.log_info('Launching model training job: %s', body)
+    self.log_info('Launching model training job @ %s: %s', parent, body)
     response = client.projects().locations().models() \
                      .create(parent=parent, body=body).execute()
     self.log_info('Launched model training job: %s', response)

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -1525,24 +1525,27 @@ class AutoMLImporter(AutoMLWorker):
   """Worker to create AutoML datasets by importing data from Bigquery or GCS."""
 
   PARAMS = [
-      ('dataset_project_id', 'string', True, '', 'AutoML Project ID'),
-      ('dataset_location', 'string', True, '', 'AutoML Dataset Location'),
-      ('dataset_name', 'string', True, '', 'Dataset Name'),
-      ('strftime_format', 'string', True, '', 'strftime format code (appended to name for uniqueness)'),
-      ('dataset_metadata', 'text', True, '', 'Dataset metadata in JSON'),
-      ('input_bq_uri', 'string', False, '',
-       'Input - BigQuery Table URI (e.g. bq://projectId.dataset.table)'),
-      ('input_gcs_uri', 'string', False, '',
-       'Input - Cloud Storage CSV URI (e.g. gs://bucket/directory/file.csv)'),
+    ('dataset_project_id', 'string', True, '', 'AutoML Project ID'),
+    ('dataset_location', 'string', True, '', 'AutoML Dataset Location'),
+    ('dataset_name', 'string', True, '', 'Dataset Name'),
+    ('strftime_format', 'string', False, '', 'strftime format code (appended to name for uniqueness)'),
+    ('dataset_metadata', 'text', True, '', 'Dataset metadata in JSON'),
+    ('input_bq_uri', 'string', False, '',
+      'Input - BigQuery Table URI (e.g. bq://projectId.dataset.table)'),
+    ('input_gcs_uri', 'string', False, '',
+      'Input - Cloud Storage CSV URI (e.g. gs://bucket/directory/file.csv)'),
   ]
 
   def _execute(self):
-    strftime_format = datetime.now().strftime(self._params['strftime_format'])
-    display_name = self._params['dataset_name'] + strftime_format
+    display_name = self._params['dataset_name']
+    strftime_format = self._params['strftime_format']
+    if strftime_format:
+      strftime = datetime.now().strftime(self._params['strftime_format'])
+      display_name += strftime
 
     # Construct the fully-qualified dataset name and config for the import.
-    dataset_parent = self._get_dataset_parent_name(self._params['dataset_project_id'],
-                                           self._params['dataset_location'])
+    dataset_parent = self._get_dataset_parent_name(self._params['dataset_project_id'], 
+                                                   self._params['dataset_location'])
                                       
     body = {
       'displayName': display_name,
@@ -1561,7 +1564,7 @@ class AutoMLImporter(AutoMLWorker):
     self.log_info('Created dataset at: %s', dataset_name)
 
     body = {
-        'inputConfig': self._generate_input_config()
+      'inputConfig': self._generate_input_config()
     }
 
     # Launch the data import and retrieve its operation name so we can track it.

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -1546,10 +1546,16 @@ class AutoMLImporter(AutoMLWorker):
     # Construct the fully-qualified dataset name and config for the import.
     dataset_parent = self._get_dataset_parent_name(self._params['dataset_project_id'], 
                                                    self._params['dataset_location'])
+
+    dataset_metadata = self._params['dataset_metadata']
+    if dataset_metadata:
+      metadata = json.loads(dataset_metadata)
+    else:
+      metadata = {}
                                       
     body = {
       'displayName': display_name,
-      'tablesDatasetMetadata': json.loads(self._params['dataset_metadata'])
+      'tablesDatasetMetadata': metadata
     }
 
     # Launch the dataset creation and retrieve the fully qualified name.

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -1574,9 +1574,12 @@ class AutoMLImporter(AutoMLWorker):
     
     self.log_info('Launched data import job: %s -> %s', body, response)
 
+    # Since the data import might take more than the 10 minutes the job
+    # service has to serve a response to the Push Queue, we can't wait on it
+    # here. We thus spawn a worker that waits until the operation is completed.
     operation_name = response.get('name')
-    waiter_params = {'operation_name': operation_name, 'delay': 15}
-    self._enqueue('AutoMLWaiter', waiter_params, 15)
+    waiter_params = {'operation_name': operation_name, 'delay': 5 * 60}
+    self._enqueue('AutoMLWaiter', waiter_params, 60)
 
   def _generate_input_config(self):
     """Constructs the input configuration for the data import request."""

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from datetime import timedelta
 from fnmatch import fnmatch
 from functools import wraps
+from pprint import pprint
 import json
 import os
 from random import random

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -1412,7 +1412,7 @@ class AutoMLWorker(Worker):
     return build('automl', 'v1beta1', credentials=credentials)
   
   @staticmethod
-  def _get_dataset_parent_name(project, location):
+  def _get_automl_parent_name(project, location):
     """Constructs the parent location path."""
     return "projects/{project}/locations/{location}".format(
         project=project,
@@ -1423,7 +1423,7 @@ class AutoMLWorker(Worker):
   def _get_full_model_name(project, location, model):
     """Constructs the fully-qualified name for the given AutoML model."""
     return "{parent}/models/{model}".format(
-        parent=AutoMLWorker._get_dataset_parent_name(project, location),
+        parent=AutoMLWorker._get_automl_parent_name(project, location),
         model=model,
     )
   
@@ -1431,7 +1431,7 @@ class AutoMLWorker(Worker):
   def _get_full_dataset_name(project, location, dataset):
     """Constructs the fully-qualified name for the given AutoML dataset."""
     return "{parent}/datasets/{dataset}".format(
-        parent=AutoMLWorker._get_dataset_parent_name(project, location),
+        parent=AutoMLWorker._get_automl_parent_name(project, location),
         dataset=dataset,
     )
 
@@ -1529,7 +1529,7 @@ class AutoMLImporter(AutoMLWorker):
     ('dataset_location', 'string', True, '', 'AutoML Dataset Location'),
     ('dataset_name', 'string', True, '', 'Dataset Name'),
     ('strftime_format', 'string', False, '', 'strftime format code (appended to name for uniqueness)'),
-    ('dataset_metadata', 'text', True, '', 'Dataset metadata in JSON'),
+    ('dataset_metadata', 'text', False, '', 'Dataset metadata in JSON'),
     ('input_bq_uri', 'string', False, '',
       'Input - BigQuery Table URI (e.g. bq://projectId.dataset.table)'),
     ('input_gcs_uri', 'string', False, '',
@@ -1543,9 +1543,8 @@ class AutoMLImporter(AutoMLWorker):
       strftime = datetime.now().strftime(self._params['strftime_format'])
       display_name += strftime
 
-    # Construct the fully-qualified dataset name and config for the import.
-    dataset_parent = self._get_dataset_parent_name(self._params['dataset_project_id'], 
-                                                   self._params['dataset_location'])
+    parent = self._get_automl_parent_name(self._params['dataset_project_id'], 
+                                                  self._params['dataset_location'])
 
     dataset_metadata = self._params['dataset_metadata']
     if dataset_metadata:
@@ -1561,7 +1560,7 @@ class AutoMLImporter(AutoMLWorker):
     # Launch the dataset creation and retrieve the fully qualified name.
     client = self._get_automl_client()
     response = client.projects().locations().datasets() \
-                     .create(parent=dataset_parent, body=body).execute()
+                     .create(parent=parent, body=body).execute()
     
     self.log_info('Launched dataset creation job: %s -> %s', body, response)
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,1 @@
+sudo APPLICATION_ID='booking-argon' docker-compose build --no-cache

--- a/docker/backends/Dockerfile
+++ b/docker/backends/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /root
 
 # Download Google App Engine SDK
 RUN apk add --no-cache --virtual .bootstrap-deps wget ca-certificates \
-    && wget -O cloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-217.0.0-linux-x86_64.tar.gz \
+    && wget -O cloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-296.0.1-linux-x86_64.tar.gz \
     && tar xzf cloud.tar.gz \
     && rm cloud.tar.gz \
     && apk del .bootstrap-deps
@@ -76,7 +76,7 @@ WORKDIR /app
 COPY ./backends/ /app/backends
 
 # We need bash to run multiline commands in docker-compose.
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash vim
 
 CMD /root/google-cloud-sdk/platform/google_appengine/dev_appserver.py \
       --skip_sdk_update_check \

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+sudo APPLICATION_ID='booking-argon' docker-compose up


### PR DESCRIPTION
Hey team!

This PR adds:
- New workers to:
  - Ingest BQ/GCS data to AutoML dataset
  - Train AutoML model from dataset
- Bugfix: Pins python-rsa to v4.0, as oauthlib does not pin and later versions are py3 only.
- Feature: Added delay param to AutoML Waiter.
- Feature: Added name+strftime format as params for AutoML dataset/model dynamic names.

Things to note:
- Users can provide a strftime format to add context/uniqueness to the dataset/model name.
- ~~If you pipeline together `Ingestion -> Train -> Predict`, each intermediary step takes a Name, but needs the generated API-side ID from the previous one. I am still investigating the easiest way to solve this.~~
- The Trainer & Predictor workers now take a name+strftime to search for the latest match and use that. This also allows for incremental runs of the (now stateless) pipeline, in case manual intervention is needed.

Do test this out and let me know your thoughts!