### PR TITLE
Add support for choosing AutoML model input features

### DIFF
--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -1528,7 +1528,7 @@ class AutoMLPredictor(AutoMLWorker):
     # here. We thus spawn a worker that waits until the operation is completed.
     operation_name = response.get('name')
     waiter_params = {'operation_name': operation_name, 'location': model_location}
-    self._enqueue('AutoMLWaiter', waiter_params, 60)
+    self._enqueue('AutoMLWaiter', waiter_params, 5 * 60)
 
   def _generate_input_config(self):
     """Constructs the input configuration for the batch prediction request."""
@@ -1588,7 +1588,7 @@ class AutoMLWaiter(AutoMLWorker):
         self.log_info('AutoML operation completed successfully: %s', response)
     else:
       self.log_info('AutoML operation still running: %s', response)
-      self._enqueue('AutoMLWaiter', self._params, self._params.get('delay') or 60)
+      self._enqueue('AutoMLWaiter', self._params, self._params.get('delay', 60))
 
 
 class AutoMLImporter(AutoMLWorker):
@@ -1653,10 +1653,10 @@ class AutoMLImporter(AutoMLWorker):
     operation_name = response.get('name')
     waiter_params = {
       'operation_name': operation_name,
-      'delay': 5 * 60,
+      'delay': 15 * 60,
       'location': dataset_location,
     }
-    self._enqueue('AutoMLWaiter', waiter_params, 60)
+    self._enqueue('AutoMLWaiter', waiter_params, 5 * 60)
 
   def _generate_input_config(self):
     """Constructs the input configuration for the data import request."""
@@ -1733,10 +1733,10 @@ class AutoMLTrainer(AutoMLWorker):
     operation_name = response.get('name')
     waiter_params = {
       'operation_name': operation_name,
-      'delay': self._params['training_budget'] * 60 * 30,
+      'delay': self._params['training_budget'] * 60 * 30 - 5 * 60,
       'location': model_location,
     }
-    self._enqueue('AutoMLWaiter', waiter_params, 60)
+    self._enqueue('AutoMLWaiter', waiter_params, 5 * 60)
 
   def _generate_model_metadata(self, target_column_spec, training_columns_specs):
     model_metadata = {

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -1588,7 +1588,7 @@ class AutoMLWaiter(AutoMLWorker):
         self.log_info('AutoML operation completed successfully: %s', response)
     else:
       self.log_info('AutoML operation still running: %s', response)
-      self._enqueue('AutoMLWaiter', self._params, self._params.get('delay', 60))
+      self._enqueue('AutoMLWaiter', self._params, self._params.get('delay', 10 * 60))
 
 
 class AutoMLImporter(AutoMLWorker):
@@ -1656,7 +1656,7 @@ class AutoMLImporter(AutoMLWorker):
       'delay': 15 * 60,
       'location': dataset_location,
     }
-    self._enqueue('AutoMLWaiter', waiter_params, 5 * 60)
+    self._enqueue('AutoMLWaiter', waiter_params, 15 * 60)
 
   def _generate_input_config(self):
     """Constructs the input configuration for the data import request."""
@@ -1733,10 +1733,10 @@ class AutoMLTrainer(AutoMLWorker):
     operation_name = response.get('name')
     waiter_params = {
       'operation_name': operation_name,
-      'delay': self._params['training_budget'] * 60 * 30 - 5 * 60,
+      'delay': self._params['training_budget'] * 60 * 30,
       'location': model_location,
     }
-    self._enqueue('AutoMLWaiter', waiter_params, 5 * 60)
+    self._enqueue('AutoMLWaiter', waiter_params, 15 * 60)
 
   def _generate_model_metadata(self, target_column_spec, training_columns_specs):
     model_metadata = {

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -1683,7 +1683,7 @@ class AutoMLTrainer(AutoMLWorker):
       ('dataset_name', 'string', False, '', 'AutoML Dataset Name'),
       ('dataset_strftime_format', 'string', False, '', 'AutoML Dataset strftime format'),
       ('training_columns', 'string_list', False, '', 'Training Column names (else, all are used)'),
-      ('target_column', 'string', True, '', 'Target Column name (remaining are used for input)'),
+      ('target_column', 'string', True, '', 'Target Column name'),
       ('optimization_objective', 'string', False, '', 'Optimization objective'),
       ('training_budget', 'number', True, '', 'Training budget (in hours)'),
       ('stop_early', 'boolean', True, False, 'Stop training early (if possible)'),

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,0 @@
-sudo APPLICATION_ID='<GCP-PROJECT-ID>' docker-compose build --no-cache

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,0 @@
-sudo APPLICATION_ID='booking-argon' docker-compose up


### PR DESCRIPTION
Hi team!

I've added support to the AutoMLTrainer worker to allow users to choose which columns are used for training. I've also tweaked the AutoMLWaiter delays for the AutoML workers, to enable easier synchronisation between them.

Thanks!

p.s I've also removed my local runner scripts that I'd accidentally added in my previous PR.