### PR TITLE
Added null marker and schema fields for CSV importer

### DIFF
--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -376,27 +376,28 @@ class StorageToBQImporter(StorageWorker, BQWorker):
     fields = field.get('fields', [])
 
     if fields:
-        subschema = bigquery.TableFieldSchema()
+        subschema = []
         for f in fields:
             fields_res = _get_field_schema(f)
-            subschema.fields.append(fields_res)
+            subschema.append(fields_res)
     else:
-        subschema = bigquery.TableFieldSchema()
+        subschema = []
 
-    field_schema = bigquery.TableFieldSchema()
-    field_schema.name = name
-    field_schema.type = field_type
-    field_schema.mode = mode
-    field_schema.fields = subschema
+    field_schema = bigquery.schema.SchemaField(
+      name=name,
+      field_type=field_type,
+      mode=mode,
+      fields=tuple(subschema)
+    )
 
     return field_schema
 
   def _parse_bq_json_schema(schema_json_string):
-    table_schema = bigquery.TableSchema()
+    table_schema = []
     jsonschema = json.loads(schema_json_string)
 
     for field in jsonschema:
-        table_schema.fields.append(_get_field_schema(field))
+        table_schema.append(_get_field_schema(field))
 
     return table_schema
 

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -376,12 +376,12 @@ class StorageToBQImporter(StorageWorker, BQWorker):
     fields = field.get('fields', [])
 
     if fields:
-        subschema = []
-        for f in fields:
-            fields_res = _get_field_schema(f)
-            subschema.append(fields_res)
+      subschema = []
+      for f in fields:
+        fields_res = _get_field_schema(f)
+        subschema.append(fields_res)
     else:
-        subschema = []
+      subschema = []
 
     field_schema = bigquery.schema.SchemaField(
       name=name,
@@ -397,7 +397,7 @@ class StorageToBQImporter(StorageWorker, BQWorker):
     jsonschema = json.loads(schema_json_string)
 
     for field in jsonschema:
-        table_schema.append(_get_field_schema(field))
+      table_schema.append(_get_field_schema(field))
 
     return table_schema
 


### PR DESCRIPTION
Added null_marker and schema definition fields in the StorageToBQImporter.
When importing CSV files it would be nice to set the null_marker value. From time to time the auto schema in BQ does not detect accurately and requires us to define the schema upfront, hence added a field to define schema in JSON format.