### PR TITLE
Bug/202

### DIFF
--- a/backends/core/requirements_dev.txt
+++ b/backends/core/requirements_dev.txt
@@ -1,3 +1,3 @@
 requests_toolbelt==0.8.0
-requests==2.22.0
+requests==2.18.4
 

--- a/backends/core/workers.py
+++ b/backends/core/workers.py
@@ -157,9 +157,10 @@ class Worker(object):
           if e.code > 399 and e.code < 500:
             raise e
         except Exception as e:  # pylint: disable=broad-except
-          tries += 1
-          delay = 5 * 2 ** (tries + random())
-          time.sleep(delay)
+          pass
+        tries += 1
+        delay = 5 * 2 ** (tries + random())
+        time.sleep(delay)
       return func(*args, **kwargs)
     return func_with_retries
 

--- a/docker/backends/Dockerfile
+++ b/docker/backends/Dockerfile
@@ -63,7 +63,7 @@ RUN apk update && apk add build-base gcc musl-dev libxml2-dev libxslt-dev
 WORKDIR /app/backends
 RUN apk add --update mariadb-client-libs \
     && apk add --no-cache --virtual .bootstrap-deps linux-headers \
-        bash curl python-dev musl-dev mariadb-dev gcc build-base \
+        bash curl python-dev musl-dev mariadb-dev gcc build-base git \
     && pip install -r core/requirements_dev.txt -t lib_dev \
     && pip install -r ibackend/requirements.txt -t lib \
     && pip install -r jbackend/requirements.txt -t lib \


### PR DESCRIPTION
Fix a logic error in Worker#retry() wrapper method.

The error resulted in an infinite retry loop without exponential delay in cases when HTTP requests being retried were returning 5xx codes.

This led to the "Quota Error: Rate limit for writes exceeded" error returned by the Google Analytics Management API due to an internal bug in [Remarketing Audiences: update](https://developers.google.com/analytics/devguides/config/mgmt/v3/mgmtReference/management/remarketingAudience/update) method.