### PR TITLE
Fix mysql compilation

### DIFF
--- a/backends/core/requirements.txt
+++ b/backends/core/requirements.txt
@@ -6,7 +6,7 @@ Flask-Migrate==2.0.3
 #Flask-SQLAlchemy==2.3.2
 # NB: Flask SQLAlchemy is only compatible with Flask 1.0+ in master branch for now
 git+https://github.com/dulacp/flask-sqlalchemy.git@python27-compat#egg=Flask-SQLAlchemy
-SQLAlchemy==1.3.18
+SQLAlchemy==1.3.24
 MySQL-python==1.2.5
 sqlalchemy_mixins==0.2.2
 google-cloud-bigquery==0.27

--- a/cli/commands/cloud.py
+++ b/cli/commands/cloud.py
@@ -346,6 +346,9 @@ def deploy_dispatch_rules(stage, debug=False):
 
 def install_backends_dependencies(stage, debug=False):
   commands = [
+      # HACK: fix missing MySQL header for compilation
+      "sudo wget https://raw.githubusercontent.com/paulfitz/mysql-connector-c/master/include/my_config.h -P /usr/include/mysql/",
+      # Install dependencies in virtualenv
       "virtualenv --python=python2 env",
       "mkdir -p lib",
       "pip install -r ibackend/requirements.txt -t lib",


### PR DESCRIPTION
We were facing this error while install SQLAlchemy:

```sh
ERROR: Command errored out with exit status 1:
     command: ~/crmint/venv/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-5jVSYi/mysql-python/setup.py'"'"'; __file__='"'"'/tmp/pip-install-5jVSYi/mysql-python/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-JcfFkM/install-record.txt --single-version-externally-managed --home /tmp/pip-target-0tlf7a --compile --install-headers include/site/python2.7/MySQL-python
         cwd: /tmp/pip-install-5jVSYi/mysql-python/
    Complete output (30 lines):
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-2.7
    copying _mysql_exceptions.py -> build/lib.linux-x86_64-2.7
    creating build/lib.linux-x86_64-2.7/MySQLdb
    copying MySQLdb/__init__.py -> build/lib.linux-x86_64-2.7/MySQLdb
    copying MySQLdb/converters.py -> build/lib.linux-x86_64-2.7/MySQLdb
    copying MySQLdb/connections.py -> build/lib.linux-x86_64-2.7/MySQLdb
    copying MySQLdb/cursors.py -> build/lib.linux-x86_64-2.7/MySQLdb
    copying MySQLdb/release.py -> build/lib.linux-x86_64-2.7/MySQLdb
    copying MySQLdb/times.py -> build/lib.linux-x86_64-2.7/MySQLdb
    creating build/lib.linux-x86_64-2.7/MySQLdb/constants
    copying MySQLdb/constants/__init__.py -> build/lib.linux-x86_64-2.7/MySQLdb/constants
    copying MySQLdb/constants/CR.py -> build/lib.linux-x86_64-2.7/MySQLdb/constants
    copying MySQLdb/constants/FIELD_TYPE.py -> build/lib.linux-x86_64-2.7/MySQLdb/constants
    copying MySQLdb/constants/ER.py -> build/lib.linux-x86_64-2.7/MySQLdb/constants
    copying MySQLdb/constants/FLAG.py -> build/lib.linux-x86_64-2.7/MySQLdb/constants
    copying MySQLdb/constants/REFRESH.py -> build/lib.linux-x86_64-2.7/MySQLdb/constants
    copying MySQLdb/constants/CLIENT.py -> build/lib.linux-x86_64-2.7/MySQLdb/constants
    running build_ext
    building '_mysql' extension
    creating build/temp.linux-x86_64-2.7
    x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2 -g -fdebug-prefix-map=/build/python2.7-2.7.16=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Dversion_info=(1,2,5,'final',1) -D__version__=1.2.5 -I/usr/include/mysql -I/usr/include/python2.7 -c _mysql.c -o build/temp.linux-x86_64-2.7/_mysql.o
    _mysql.c:44:10: fatal error: my_config.h: No such file or directory
     #include "my_config.h"
              ^~~~~~~~~~~~~
    compilation terminated.
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```

As the error is suggesting, we are missing the `my_config.h` header file, which this PR will fix.