### PR TITLE
Increase instance class to F4

### DIFF
--- a/backend/jobs_app.yaml
+++ b/backend/jobs_app.yaml
@@ -14,7 +14,7 @@
 
 service: crmint-jobs
 
-instance_class: F2
+instance_class: F4
 automatic_scaling:
   max_instances: 7
   target_cpu_utilization: 0.9


### PR DESCRIPTION
+ Ups the instance class for the crmint-jobs service to accommodate higher memory limits.
+ This is often seen with the GADataImporter worker which requires downloading up to 1GB file from Cloud Storage into memory.