### PR TITLE
Fix some issues with the Dockerized CLI

### DIFF
--- a/.github/workflows/testing-backend.yml
+++ b/.github/workflows/testing-backend.yml
@@ -5,6 +5,9 @@ on:
   push:
     paths-ignore:
       - 'README.md'
+  pull_request:
+    branches:
+      - 'master'
 jobs:
   run-controller-tests:
     runs-on: ubuntu-18.04

--- a/.github/workflows/testing-cli.yml
+++ b/.github/workflows/testing-cli.yml
@@ -5,6 +5,9 @@ on:
   push:
     paths-ignore:
       - 'README.md'
+  pull_request:
+    branches:
+      - 'master'
 jobs:
   run-cli-tests:
     runs-on: ubuntu-18.04

--- a/.github/workflows/testing-frontend.yml
+++ b/.github/workflows/testing-frontend.yml
@@ -5,6 +5,9 @@ on:
   push:
     paths-ignore:
       - 'README.md'
+  pull_request:
+    branches:
+      - 'master'
 jobs:
   run-frontend-tests:
     runs-on: ubuntu-18.04

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -3,3 +3,4 @@ stages/*.py
 build/
 dist/
 insight.json
+.env

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10-slim-bullseye
 
 # Installs building tools.
 RUN apt-get update \
-    && apt-get -y install curl unzip \
+    && apt-get -y install curl dnsutils unzip \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \

--- a/cli/commands/cloud.py
+++ b/cli/commands/cloud.py
@@ -140,7 +140,7 @@ def patch_etc_hosts(debug: bool = False) -> None:
 
 def unpatch_etc_hosts(debug: bool = False) -> None:
   """Restores the `/etc/hosts` file."""
-  cmd = 'sudo cp /etc/hosts.backup /etc/hosts'
+  cmd = 'cp /etc/hosts.backup /etc/hosts'
   shared.execute_command(
       'Restore /etc/hosts', cmd, cwd='./cli', debug=debug)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,7 +49,7 @@ function crmint {
   docker run --rm -it --net=host \
     -v \$HOME/crmint/cli:/app/cli \
     -v \$HOME/crmint/terraform:/app/terraform \
-    -v \$GCLOUD_CONFIG_PATH/.config:/root/.config/gcloud \
+    -v \$GCLOUD_CONFIG_PATH:/root/.config/gcloud \
     europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/cli:latest \
     crmint \$@
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,7 +20,7 @@
 # if you want to expose the crmint bash function to the
 # parent shell session.
 
-TARGET_BRANCH=${1:-master}
+TARGET_BRANCH=$1
 
 # Downloads the source code.
 if [ ! -d $HOME/crmint ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,7 +40,7 @@ echo -e "\nAdding a bash function to your $HOME/.bashrc file."
 cat <<EOF >$HOME/.crmint
 # CRMint wrapper function.
 function crmint {
-  # CloudShell stores gcloud config in a tmp directory at `\$CLOUDSDK_CONFIG`.
+  # CloudShell stores gcloud config in a tmp directory at \`\$CLOUDSDK_CONFIG\`.
   # But to also work on local environments we default to the user home config.
   GCLOUD_CONFIG_PATH="\${CLOUDSDK_CONFIG:-\$HOME/.config/gcloud}"
   echo "Using gcloud config: \$GCLOUD_CONFIG_PATH"


### PR DESCRIPTION
Bunch of fixes for the new CLI:

- Fixed the path to gcloud credentials
- Run `terraform plan` in our CI test suite
- Support specific env variables in the CLI (`USE_VPC=0` for example)
- Patching the `/etc/hosts` inside the Docker container, not corrupting your local Cloud Shell environment