### PR TITLE
Simplify our IAM configuration

### DIFF
--- a/terraform/iam_policies.tf
+++ b/terraform/iam_policies.tf
@@ -168,7 +168,7 @@ resource "google_cloud_run_service_iam_binding" "frontend_run-invoker" {
   project = google_cloud_run_service.frontend_run.project
   service = google_cloud_run_service.frontend_run.name
   role = "roles/run.invoker"
-  members = ["allUsers"]
+  members = ["serviceAccount:${google_project_service_identity.iap_sa.email}"]
 }
 
 resource "google_cloud_run_service_iam_binding" "controller_run-invoker" {
@@ -176,7 +176,7 @@ resource "google_cloud_run_service_iam_binding" "controller_run-invoker" {
   project = google_cloud_run_service.controller_run.project
   service = google_cloud_run_service.controller_run.name
   role = "roles/run.invoker"
-  members = ["allUsers"]
+  members = ["serviceAccount:${google_project_service_identity.iap_sa.email}"]
 }
 
 resource "google_cloud_run_service_iam_binding" "jobs_run-invoker" {
@@ -184,5 +184,5 @@ resource "google_cloud_run_service_iam_binding" "jobs_run-invoker" {
   project = google_cloud_run_service.jobs_run.project
   service = google_cloud_run_service.jobs_run.name
   role = "roles/run.invoker"
-  members = ["allUsers"]
+  members = ["serviceAccount:${google_project_service_identity.iap_sa.email}"]
 }

--- a/terraform/identity_aware_proxy.tf
+++ b/terraform/identity_aware_proxy.tf
@@ -20,9 +20,3 @@ resource "google_project_service_identity" "iap_sa" {
   project  = google_project_service.iap_service.project
   service  = "iap.googleapis.com"
 }
-
-resource "google_project_iam_member" "iap_sa--run_invoker" {
-  project = google_project_service.iap_service.project
-  role    = "roles/run.invoker"
-  member  = "serviceAccount:${google_project_service_identity.iap_sa.email}"
-}


### PR DESCRIPTION
Removing the `allUsers` access to our Cloud Run services, since some organizations can have the Domain Restricted Sharing policy in place for example which disables public services.