### PR TITLE
Run the install.sh script as part of our Continuous Integration workflows

### DIFF
--- a/.github/workflows/testing-cli.yml
+++ b/.github/workflows/testing-cli.yml
@@ -31,3 +31,24 @@ jobs:
           working-directory: cli
           fail_ci_if_error: false
           flags: cli
+  install-cli-test:
+    runs-on: ubuntu-18.04
+    env:
+      CRMINT_CLI_DOCKER_IMAGE: crmint/cli:latest
+      CRMINT_HOME: ${{ github.workspace }}
+      # Fakes a gcloud config path locally
+      CLOUDSDK_CONFIG: ${{ github.workspace }}/.config/gcloud
+    steps:
+      # Checkout repository code
+      - uses: actions/checkout@v3
+      # Build the CLI wrapper image
+      - name: Build CLI image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./cli/Dockerfile
+          push: false
+          tags: crmint/cli:latest
+      # Install the CLI using our install script
+      - name: Install CLI
+        run: source scripts/install.sh

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -85,13 +85,8 @@ function crmint {
   # Updates the env file with current defined env variables.
   dump_env_for_crmint_cli
 
-  # Only include the interactive mode if the shell is attached to a TTY.
-  if [ -t 0 ] ; then
-    INTERACTIVE_OPTIONS="-it"
-  fi
-
   # Runs the CLI with mounted volumes (to simplify local developement).
-  docker run --rm \$INTERACTIVE_OPTIONS --net=host \
+  docker run --rm --interactive --net=host \
     --env-file $CRMINT_HOME/cli/.env \
     -v $CRMINT_HOME/cli:/app/cli \
     -v $CRMINT_HOME/terraform:/app/terraform \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,18 +30,18 @@ TARGET_BRANCH=$1
 CRMINT_CLI_DOCKER_IMAGE=${CRMINT_CLI_DOCKER_IMAGE:-europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/cli:latest}
 
 # Allows advanced users to change the home directory for crmint repository.
-# Defaults to `$HOME`.
-CRMINT_HOME=${CRMINT_HOME:-$HOME}
+# Defaults to `$HOME/crmint`.
+CRMINT_HOME=${CRMINT_HOME:-$HOME/crmint}
 
 # Downloads the source code.
-if [ ! -d $CRMINT_HOME/crmint ]; then
-  git clone https://github.com/google/crmint.git $CRMINT_HOME/crmint
-  echo -e "\nCloned crmint repository to your home directory: $CRMINT_HOME."
+if [ ! -d $CRMINT_HOME ]; then
+  git clone https://github.com/google/crmint.git $CRMINT_HOME
+  echo -e "\nCloned crmint repository to: $CRMINT_HOME."
 fi
 
 # Updates the targeted branch.
 CURRENT_DIR=$(pwd)
-cd $CRMINT_HOME/crmint
+cd $CRMINT_HOME
 git checkout $TARGET_BRANCH
 git pull --rebase
 cd "$CURRENT_DIR"
@@ -62,7 +62,7 @@ function dump_env_for_crmint_cli {
     "JOBS_IMAGE"
   )
 
-  output_file="$CRMINT_HOME/crmint/cli/.env"
+  output_file="$CRMINT_HOME/cli/.env"
   touch \$output_file  # Ensures the file exists even if no variables are set.
 
   for var in "\${env_vars[@]}"
@@ -85,9 +85,9 @@ function crmint {
 
   # Runs the CLI with mounted volumes (to simplify local developement).
   docker run --rm -it --net=host \
-    --env-file $CRMINT_HOME/crmint/cli/.env \
-    -v $CRMINT_HOME/crmint/cli:/app/cli \
-    -v $CRMINT_HOME/crmint/terraform:/app/terraform \
+    --env-file $CRMINT_HOME/cli/.env \
+    -v $CRMINT_HOME/cli:/app/cli \
+    -v $CRMINT_HOME/terraform:/app/terraform \
     -v \$GCLOUD_CONFIG_PATH:/root/.config/gcloud \
     $CRMINT_CLI_DOCKER_IMAGE \
     crmint \$@

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -39,12 +39,14 @@ if [ ! -d $CRMINT_HOME ]; then
   echo -e "\nCloned crmint repository to: $CRMINT_HOME."
 fi
 
-# Updates the targeted branch.
-CURRENT_DIR=$(pwd)
-cd $CRMINT_HOME
-git checkout $TARGET_BRANCH
-git pull --rebase
-cd "$CURRENT_DIR"
+# Updates the targeted branch (if it's a git repository only).
+if [ ! -d $CRMINT_HOME/.git ]; then
+  CURRENT_DIR=$(pwd)
+  cd $CRMINT_HOME
+  git checkout $TARGET_BRANCH
+  git pull --rebase
+  cd "$CURRENT_DIR"
+fi
 
 # Adds the wrapper function to our `.crmint` utility file.
 echo -e "\nAdding a bash function to your $HOME/.bashrc file."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,15 +22,26 @@
 
 TARGET_BRANCH=$1
 
+# Allows advanced users to use their own CLI wrapper docker image.
+#
+# NOTE: this is only a wrapper image since the `./cli` local directory is
+#       mounted on this container and allow you to develop locally.
+#
+CRMINT_CLI_DOCKER_IMAGE=${CRMINT_CLI_DOCKER_IMAGE:-europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/cli:latest}
+
+# Allows advanced users to change the home directory for crmint repository.
+# Defaults to `$HOME`.
+CRMINT_HOME=${CRMINT_HOME:-$HOME}
+
 # Downloads the source code.
-if [ ! -d $HOME/crmint ]; then
-  git clone https://github.com/google/crmint.git $HOME/crmint
-  echo -e "\nCloned crmint repository to your home directory: $HOME."
+if [ ! -d $CRMINT_HOME/crmint ]; then
+  git clone https://github.com/google/crmint.git $CRMINT_HOME/crmint
+  echo -e "\nCloned crmint repository to your home directory: $CRMINT_HOME."
 fi
 
 # Updates the targeted branch.
 CURRENT_DIR=$(pwd)
-cd $HOME/crmint
+cd $CRMINT_HOME/crmint
 git checkout $TARGET_BRANCH
 git pull --rebase
 cd "$CURRENT_DIR"
@@ -51,7 +62,7 @@ function dump_env_for_crmint_cli {
     "JOBS_IMAGE"
   )
 
-  output_file="\$HOME/crmint/cli/.env"
+  output_file="$CRMINT_HOME/crmint/cli/.env"
   touch \$output_file  # Ensures the file exists even if no variables are set.
 
   for var in "\${env_vars[@]}"
@@ -74,11 +85,11 @@ function crmint {
 
   # Runs the CLI with mounted volumes (to simplify local developement).
   docker run --rm -it --net=host \
-    --env-file \$HOME/crmint/cli/.env \
-    -v \$HOME/crmint/cli:/app/cli \
-    -v \$HOME/crmint/terraform:/app/terraform \
+    --env-file $CRMINT_HOME/crmint/cli/.env \
+    -v $CRMINT_HOME/crmint/cli:/app/cli \
+    -v $CRMINT_HOME/crmint/terraform:/app/terraform \
     -v \$GCLOUD_CONFIG_PATH:/root/.config/gcloud \
-    europe-docker.pkg.dev/instant-bqml-demo-environment/crmint/cli:latest \
+    $CRMINT_CLI_DOCKER_IMAGE \
     crmint \$@
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -85,8 +85,13 @@ function crmint {
   # Updates the env file with current defined env variables.
   dump_env_for_crmint_cli
 
+  # Only include the interactive mode if the shell is attached to a TTY.
+  if [ -t 0 ] ; then
+    INTERACTIVE_OPTIONS="-it"
+  fi
+
   # Runs the CLI with mounted volumes (to simplify local developement).
-  docker run --rm -it --net=host \
+  docker run --rm \$INTERACTIVE_OPTIONS --net=host \
     --env-file $CRMINT_HOME/cli/.env \
     -v $CRMINT_HOME/cli:/app/cli \
     -v $CRMINT_HOME/terraform:/app/terraform \


### PR DESCRIPTION
The `scripts/install.sh` script could easily break new CRMint installations, we want to ensure that each update to our main branch will still allow the CLI to be correctly installed.