### PR TITLE
Add support for using a pre-existing IAP Brand with CRMint

### DIFF
--- a/cli/utils/shared.py
+++ b/cli/utils/shared.py
@@ -307,6 +307,7 @@ def default_stage_context(*,
   namespace = types.SimpleNamespace(
       app_title=app_title,
       notification_sender_email=gcloud_account_email,
+      iap_brand_id=None,
       iap_support_email=gcloud_account_email,
       iap_allowed_users=[f'user:{gcloud_account_email}'],
       project_id=project_id,

--- a/terraform/iam_policies.tf
+++ b/terraform/iam_policies.tf
@@ -34,6 +34,12 @@ resource "google_project_service_identity" "pubsub_managed_sa" {
   service  = "pubsub.googleapis.com"
 }
 
+resource "google_project_service_identity" "iap_managed_sa" {
+  provider = google-beta
+  project  = var.project_id
+  service  = "iap.googleapis.com"
+}
+
 resource "google_project_iam_member" "controller_sa--cloudsql-client" {
   member  = "serviceAccount:${google_service_account.controller_sa.email}"
   project = var.project_id
@@ -120,4 +126,63 @@ resource "google_project_iam_member" "pubsub_token-creator" {
   member  = "serviceAccount:${google_project_service_identity.pubsub_managed_sa.email}"
   project = var.project_id
   role    = "roles/iam.serviceAccountTokenCreator"
+}
+
+##
+# Cloud Run permissions
+#
+# NOTE: We delegate the authentication flow to IAP, so we need to give `allUsers` access
+#       to Cloud Run since it's not responsible anymore for authenticating the users.
+#
+
+data "google_iam_policy" "iap_users" {
+  binding {
+    role = "roles/iap.httpsResourceAccessor"
+    members = concat(
+      ["serviceAccount:${google_service_account.pubsub_sa.email}"],
+      var.iap_allowed_users
+    )
+  }
+}
+
+resource "google_iap_web_backend_service_iam_policy" "frontend" {
+  project = google_compute_backend_service.frontend_backend.project
+  web_backend_service = google_compute_backend_service.frontend_backend.name
+  policy_data = data.google_iam_policy.iap_users.policy_data
+}
+
+resource "google_iap_web_backend_service_iam_policy" "controller" {
+  project = google_compute_backend_service.controller_backend.project
+  web_backend_service = google_compute_backend_service.controller_backend.name
+  policy_data = data.google_iam_policy.iap_users.policy_data
+}
+
+resource "google_iap_web_backend_service_iam_policy" "jobs" {
+  project = google_compute_backend_service.jobs_backend.project
+  web_backend_service = google_compute_backend_service.jobs_backend.name
+  policy_data = data.google_iam_policy.iap_users.policy_data
+}
+
+resource "google_cloud_run_service_iam_binding" "frontend_run-invoker" {
+  location = google_cloud_run_service.frontend_run.location
+  project = google_cloud_run_service.frontend_run.project
+  service = google_cloud_run_service.frontend_run.name
+  role = "roles/run.invoker"
+  members = ["allUsers"]
+}
+
+resource "google_cloud_run_service_iam_binding" "controller_run-invoker" {
+  location = google_cloud_run_service.controller_run.location
+  project = google_cloud_run_service.controller_run.project
+  service = google_cloud_run_service.controller_run.name
+  role = "roles/run.invoker"
+  members = ["allUsers"]
+}
+
+resource "google_cloud_run_service_iam_binding" "jobs_run-invoker" {
+  location = google_cloud_run_service.jobs_run.location
+  project = google_cloud_run_service.jobs_run.project
+  service = google_cloud_run_service.jobs_run.name
+  role = "roles/run.invoker"
+  members = ["allUsers"]
 }

--- a/terraform/identity_aware_proxy.tf
+++ b/terraform/identity_aware_proxy.tf
@@ -4,9 +4,15 @@ resource "google_project_service" "iap_service" {
 }
 
 resource "google_iap_brand" "default" {
+  count = var.iap_band_id == null ? 1 : 0
   support_email     = var.iap_support_email
   application_title = "Cloud IAP protected Application"
   project           = google_project_service.iap_service.project
+}
+
+resource "google_iap_client" "default" {
+  display_name = "Test Client"
+  brand        =  var.iap_band_id == null ? google_iap_brand.default[0].name : "projects/${var.project_id}/brands/${var.iap_band_id}"
 }
 
 resource "google_project_service_identity" "iap_sa" {
@@ -19,37 +25,4 @@ resource "google_project_iam_member" "iap_sa--run_invoker" {
   project = google_project_service.iap_service.project
   role    = "roles/run.invoker"
   member  = "serviceAccount:${google_project_service_identity.iap_sa.email}"
-}
-
-resource "google_iap_client" "default" {
-  display_name = "Test Client"
-  brand        =  google_iap_brand.default.name
-}
-
-data "google_iam_policy" "iap_users" {
-  binding {
-    role = "roles/iap.httpsResourceAccessor"
-    members = concat(
-      ["serviceAccount:${google_service_account.pubsub_sa.email}"],
-      var.iap_allowed_users
-    )
-  }
-}
-
-resource "google_iap_web_backend_service_iam_policy" "frontend" {
-  project = google_compute_backend_service.frontend_backend.project
-  web_backend_service = google_compute_backend_service.frontend_backend.name
-  policy_data = data.google_iam_policy.iap_users.policy_data
-}
-
-resource "google_iap_web_backend_service_iam_policy" "controller" {
-  project = google_compute_backend_service.controller_backend.project
-  web_backend_service = google_compute_backend_service.controller_backend.name
-  policy_data = data.google_iam_policy.iap_users.policy_data
-}
-
-resource "google_iap_web_backend_service_iam_policy" "jobs" {
-  project = google_compute_backend_service.jobs_backend.project
-  web_backend_service = google_compute_backend_service.jobs_backend.name
-  policy_data = data.google_iam_policy.iap_users.policy_data
 }

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -41,14 +41,6 @@ resource "google_cloud_run_service" "frontend_run" {
   }
 }
 
-resource "google_cloud_run_service_iam_member" "frontend_run-public" {
-  location = google_cloud_run_service.frontend_run.location
-  project = google_cloud_run_service.frontend_run.project
-  service = google_cloud_run_service.frontend_run.name
-  role = "roles/run.invoker"
-  member = "allUsers"
-}
-
 locals {
   cloud_db_uri = var.use_vpc ? "mysql+mysqlconnector://${google_sql_user.crmint.name}:${google_sql_user.crmint.password}@${google_sql_database_instance.main.first_ip_address}/${google_sql_database.crmint.name}" : "mysql+mysqlconnector://${google_sql_user.crmint.name}:${google_sql_user.crmint.password}@/${google_sql_database.crmint.name}?unix_socket=/cloudsql/${google_sql_database_instance.main.connection_name}"
 }
@@ -170,14 +162,6 @@ resource "google_cloud_run_service" "controller_run" {
   depends_on = [google_secret_manager_secret_version.cloud_db_uri-latest]
 }
 
-resource "google_cloud_run_service_iam_member" "controller_run-public" {
-  location = google_cloud_run_service.controller_run.location
-  project = google_cloud_run_service.controller_run.project
-  service = google_cloud_run_service.controller_run.name
-  role = "roles/run.invoker"
-  member = "allUsers"
-}
-
 resource "google_cloud_run_service" "jobs_run" {
   provider = google-beta
   name     = "jobs"
@@ -237,14 +221,6 @@ resource "google_cloud_run_service" "jobs_run" {
     percent         = 100
     latest_revision = true
   }
-}
-
-resource "google_cloud_run_service_iam_member" "jobs_run-public" {
-  location = google_cloud_run_service.jobs_run.location
-  project = google_cloud_run_service.jobs_run.project
-  service = google_cloud_run_service.jobs_run.name
-  role = "roles/run.invoker"
-  member = "allUsers"
 }
 
 resource "google_cloudbuild_worker_pool" "private" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,6 +21,11 @@ variable "notification_sender_email" {
 ##
 # Security (IAP configuration)
 
+variable "iap_band_id" {
+  description = "Existing IAP Brand ID - only INTERNAL TYPE (you can obtain it using this command: `$ gcloud iap oauth-brands list --format='value(name)' | sed 's:.*/::'`)."
+  default = null
+}
+
 variable "iap_support_email" {
   description = "Support email used for configuring IAP"
 }


### PR DESCRIPTION
Add a new Terraform variable to support existing IAP Brand.

In a few deployments, the user deploys CRMint in an existing project with a brand already configured. They can now inject the brand ID in their stage file located in: `crmint/cli/stages/<your_project_id>.tfvars.json`.