### PR TITLE
Improve deploying custom builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,20 @@ locally.
 $ act -j run-cli-tests --reuse --bind
 ```
 
+## Deploy custom build on GCP
+
+```sh
+# Clones the repo
+$ git clone https://github.com/google/crmint
+# Installs the CRMint CLI (if not already available)
+$ bash crmint/scripts/install.sh
+# Checkouts your desired branch (if needed)
+$ cd crmint
+$ git checkout <your_branch>
+# Builds and deploys everything
+$ ./scripts/build_and_deploy.sh
+```
+
 ## Community Guidelines
 
 This project follows [Google's Open Source Community

--- a/cli/commands/stages.py
+++ b/cli/commands/stages.py
@@ -84,8 +84,18 @@ def migrate(stage_path: Union[None, str], debug: bool) -> None:
 @cli.command('update')
 @click.option('--stage_path', default=None)
 @click.option('--version', default=None)
+@click.option('--controller_image', default=None)
+@click.option('--jobs_image', default=None)
+@click.option('--frontend_image', default=None)
 @click.option('--debug/--no-debug', default=False)
-def update(stage_path: Union[None, str], version: str, debug: bool) -> None:
+def update(
+    stage_path: Union[None, str],
+    version: Union[None, str],
+    controller_image: Union[None, str],
+    jobs_image: Union[None, str],
+    frontend_image: Union[None, str],
+    debug: bool
+  ) -> None:
   """Update CRMint version."""
   click.echo(click.style('>>>> Update CRMint version', fg='magenta', bold=True))
 
@@ -97,8 +107,11 @@ def update(stage_path: Union[None, str], version: str, debug: bool) -> None:
   except shared.CannotFetchStageError:
     sys.exit(1)
 
-  available_tags = shared.list_available_tags(
-      stage.controller_image, debug=debug)
+  controller_image = controller_image or stage.controller_image
+  jobs_image = jobs_image or stage.jobs_image
+  frontend_image = frontend_image or stage.frontend_image
+
+  available_tags = shared.list_available_tags(controller_image, debug=debug)
   if version is None:
     available_versions = shared.filter_versions_from_tags(available_tags)
     version = available_versions[0]
@@ -110,9 +123,9 @@ def update(stage_path: Union[None, str], version: str, debug: bool) -> None:
                            bold=True))
     sys.exit(1)
 
-  stage.frontend_image = f'{stage.frontend_image.split(":")[0]}:{version}'
-  stage.controller_image = f'{stage.controller_image.split(":")[0]}:{version}'
-  stage.jobs_image = f'{stage.jobs_image.split(":")[0]}:{version}'
+  stage.frontend_image = f'{frontend_image.split(":")[0]}:{version}'
+  stage.controller_image = f'{controller_image.split(":")[0]}:{version}'
+  stage.jobs_image = f'{jobs_image.split(":")[0]}:{version}'
   shared.create_stage_file(stage.stage_path, stage)
   click.echo(click.style(f'Stage updated to version: {version}', fg='green'))
 

--- a/scripts/build_and_deploy.sh
+++ b/scripts/build_and_deploy.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build and Deploy for local development
+#
+# NOTE: This script is only meant to build and deploy locally.
+
+DOCKER_BUILDKIT=1 docker build -t crmint-controller:dev -f ./backend/controller.Dockerfile ./backend
+DOCKER_BUILDKIT=1 docker build -t crmint-jobs:dev -f ./backend/jobs.Dockerfile ./backend
+DOCKER_BUILDKIT=1 docker build -t crmint-frontend:dev -f ./frontend/Dockerfile ./frontend
+
+# Tags the images with the user repository.
+PROJECT_ID=$(gcloud --quiet config list --format="value(core.project)")
+docker tag crmint-controller:dev europe-docker.pkg.dev/$PROJECT_ID/crmint/controller:dev
+docker tag crmint-jobs:dev europe-docker.pkg.dev/$PROJECT_ID/crmint/jobs:dev
+docker tag crmint-frontend:dev europe-docker.pkg.dev/$PROJECT_ID/crmint/frontend:dev
+
+# Pushes the images to your Artifact Registry.
+docker push europe-docker.pkg.dev/$PROJECT_ID/crmint/controller:dev
+docker push europe-docker.pkg.dev/$PROJECT_ID/crmint/jobs:dev
+docker push europe-docker.pkg.dev/$PROJECT_ID/crmint/frontend:dev
+
+# Uses our CLI to update the deployment config (called staging file).
+crmint stages create
+crmint stages update \
+    --version dev \
+    --controller_image europe-docker.pkg.dev/$PROJECT_ID/crmint/controller \
+    --jobs_image europe-docker.pkg.dev/$PROJECT_ID/crmint/jobs \
+    --frontend_image europe-docker.pkg.dev/$PROJECT_ID/crmint/frontend
+
+# Runs a new deployment
+crmint cloud setup
+crmint cloud url


### PR DESCRIPTION
We've added a script to facilitate the deployment of custom CRMint builds for new users.

This script automates the following steps:
* Builds new docker images
* Tags these images with the `:dev` label
* Creates if needed an Google Artifact Registry repository
* Pushes the images to this GAR repository
* Updates the crmint stage file with `crmint stages update`
* Deploys the containers with `crmint cloud setup`

Instructions on how to use it can be found in the `CONTRIBUTING.md` file.