### PR TITLE
Gunicorn Timeout Update

### DIFF
--- a/backend/controller/ml_model/bigquery.py
+++ b/backend/controller/ml_model/bigquery.py
@@ -18,7 +18,6 @@ import dataclasses
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
 from controller import shared
-import time
 
 
 @dataclasses.dataclass
@@ -68,8 +67,6 @@ class CustomClient(bigquery.Client):
     """
 
     variables: list[Variable] = []
-
-    time.sleep(120)
 
     event_exclude_list = [
         'user_engagement',

--- a/backend/controller/ml_model/bigquery.py
+++ b/backend/controller/ml_model/bigquery.py
@@ -18,6 +18,7 @@ import dataclasses
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
 from controller import shared
+import time
 
 
 @dataclasses.dataclass
@@ -67,6 +68,8 @@ class CustomClient(bigquery.Client):
     """
 
     variables: list[Variable] = []
+
+    time.sleep(120)
 
     event_exclude_list = [
         'user_engagement',

--- a/backend/controller_entrypoint.sh
+++ b/backend/controller_entrypoint.sh
@@ -5,5 +5,5 @@ python -m flask db upgrade
 python -m flask db-seeds
 
 # Starts the production server
-gunicorn -b :$PORT -w 3 controller_app:app
+gunicorn -b :$PORT -w 3 -t 300 controller_app:app
 


### PR DESCRIPTION
Updates controller timeout to 5 minutes to match the Cloud Run timeout for the controller.
BigQuery requests to pull events (for feature/label selection) takes more than the default 30 seconds that is allowed.