### PR TITLE
Update to Handle Boolean Type First Party Labels

### DIFF
--- a/backend/controller/ml_model/templates/model_bqml.sql
+++ b/backend/controller/ml_model/templates/model_bqml.sql
@@ -254,8 +254,8 @@ aggregate_behavior AS (
   FROM events AS e
   INNER JOIN user_variables AS uv
     ON e.unique_id = uv.unique_id
-  WHERE (uv.label > 0 AND e.date <= uv.trigger_date)
-  OR uv.label = 0
+  WHERE (CAST(uv.label AS INT64) > 0 AND e.date <= uv.trigger_date)
+  OR CAST(uv.label AS INT64) = 0
   GROUP BY 1
 ),
 unified_dataset AS (


### PR DESCRIPTION
There's an issue where it tries to compare a Boolean first party label via > (greater than) to a number. This isn't allowed and as such throws an error. The proposed change casts any values as an integer before doing the comparison so that if a Boolean is provided it will convert TRUE to 1 and FALSE to 0 and since labels are expected to be >= 1 in the event of counts or numeric values this should be a nice catchall.